### PR TITLE
revise: Create Unique Random Alphanumeric Generator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,6 +221,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
+name = "bytemuck"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94bbb0ad554ad961ddc5da507a12a29b14e4ae5bda06b19f575a3e6079d2e2ae"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -489,6 +495,7 @@ dependencies = [
  "crankshaft-config",
  "crankshaft-docker",
  "eyre",
+ "fastbloom",
  "futures",
  "indexmap 2.5.0",
  "indicatif",
@@ -611,6 +618,18 @@ checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
 dependencies = [
  "indenter",
  "once_cell",
+]
+
+[[package]]
+name = "fastbloom"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c016adea24b4c9c6931b5d3560995d8d4fd3db2ac06f017d3922dd45e6ccbd9"
+dependencies = [
+ "getrandom",
+ "rand",
+ "siphasher",
+ "wide",
 ]
 
 [[package]]
@@ -1873,6 +1892,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
+name = "safe_arch"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3460605018fdc9612bce72735cba0d27efbcd9904780d44c7e3a9948f96148a"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2038,6 +2066,12 @@ checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "siphasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slab"
@@ -2712,6 +2746,16 @@ dependencies = [
  "redox_syscall 0.5.4",
  "wasite",
  "web-sys",
+]
+
+[[package]]
+name = "wide"
+version = "0.7.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b828f995bf1e9622031f8009f8481a85406ce1f4d4588ff746d872043e855690"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ clap-verbosity-flag = "2.2.1"
 color-eyre = "0.6.3"
 dirs = "5.0.1"
 eyre = "0.6.12"
+fastbloom = "0.7.1"
 futures = "0.3.30"
 indexmap = { version = "2.5.0", features = ["serde"] }
 indicatif = "0.17.8"

--- a/crankshaft-config/src/backend/generic/builder.rs
+++ b/crankshaft-config/src/backend/generic/builder.rs
@@ -2,8 +2,8 @@
 
 use std::collections::HashMap;
 
-use crate::backend::generic::driver;
 use crate::backend::generic::Config;
+use crate::backend::generic::driver;
 
 /// An error related to a [`Builder`].
 #[derive(Debug)]

--- a/crankshaft-config/src/backend/generic/driver/builder.rs
+++ b/crankshaft-config/src/backend/generic/driver/builder.rs
@@ -1,10 +1,10 @@
 //! Builders for [command driver configuration](Config).
 
-use crate::backend::generic::driver::ssh;
 use crate::backend::generic::driver::Config;
+use crate::backend::generic::driver::DEFAULT_MAX_ATTEMPTS;
 use crate::backend::generic::driver::Locale;
 use crate::backend::generic::driver::Shell;
-use crate::backend::generic::driver::DEFAULT_MAX_ATTEMPTS;
+use crate::backend::generic::driver::ssh;
 
 /// A builder for a [command driver configuration object](Config).
 pub struct Builder {

--- a/crankshaft-config/src/backend/tes/builder.rs
+++ b/crankshaft-config/src/backend/tes/builder.rs
@@ -2,8 +2,8 @@
 
 use url::Url;
 
-use crate::backend::tes::http;
 use crate::backend::tes::Config;
+use crate::backend::tes::http;
 
 /// An error related to a [`Builder`].
 #[derive(Debug)]

--- a/crankshaft-config/src/builder.rs
+++ b/crankshaft-config/src/builder.rs
@@ -1,7 +1,7 @@
 //! Builders for a [global configuration object for Crankshaft](Config).
 
-use crate::backend;
 use crate::Config;
+use crate::backend;
 
 /// A builder for a [global configuration object for Crankshaft](Config).
 #[derive(Default)]

--- a/crankshaft-config/src/lib.rs
+++ b/crankshaft-config/src/lib.rs
@@ -10,12 +10,12 @@
 
 use std::path::Path;
 
-use config::builder::DefaultState;
 use config::Config as ConfigCrate;
 use config::ConfigBuilder;
 use config::ConfigError as Error;
 use config::Environment;
 use config::File;
+use config::builder::DefaultState;
 use serde::Deserialize;
 use serde::Serialize;
 

--- a/crankshaft-docker/src/bin/docker-driver.rs
+++ b/crankshaft-docker/src/bin/docker-driver.rs
@@ -113,18 +113,12 @@ async fn run(args: &Args) -> Result<()> {
 
     match &args.command {
         Command::CreateContainer { image, name, tag } => {
-            create_container(
-                docker,
-                image,
-                tag,
-                name,
-                [
-                    String::from("/usr/bin/env"),
-                    String::from("bash"),
-                    String::from("-c"),
-                    String::from("echo 'hello, world!'"),
-                ],
-            )
+            create_container(docker, image, tag, name, [
+                String::from("/usr/bin/env"),
+                String::from("bash"),
+                String::from("-c"),
+                String::from("echo 'hello, world!'"),
+            ])
             .await?;
         }
         Command::RunContainer {

--- a/crankshaft-docker/src/container.rs
+++ b/crankshaft-docker/src/container.rs
@@ -10,20 +10,20 @@ use std::os::windows::process::ExitStatusExt as _;
 use std::process::ExitStatus;
 use std::process::Output;
 
+use bollard::Docker;
 use bollard::container::AttachContainerOptions;
 use bollard::container::LogOutput;
 use bollard::container::RemoveContainerOptions;
 use bollard::container::StartContainerOptions;
 use bollard::container::UploadToContainerOptions;
 use bollard::container::WaitContainerOptions;
-use bollard::Docker;
 pub use builder::Builder;
 use futures::TryStreamExt as _;
 use tokio_stream::StreamExt as _;
+use tracing::Level;
 use tracing::debug;
 use tracing::enabled;
 use tracing::trace;
-use tracing::Level;
 
 use crate::Error;
 use crate::Result;

--- a/crankshaft-docker/src/container/builder.rs
+++ b/crankshaft-docker/src/container/builder.rs
@@ -1,9 +1,9 @@
 //! Builders for containers.
 
+use bollard::Docker;
 use bollard::container::Config;
 use bollard::container::CreateContainerOptions;
 use bollard::secret::HostConfig;
-use bollard::Docker;
 use tracing::warn;
 
 use crate::Container;

--- a/crankshaft-docker/src/images.rs
+++ b/crankshaft-docker/src/images.rs
@@ -8,10 +8,10 @@ use bollard::secret::ImageDeleteResponseItem;
 use bollard::secret::ImageSummary;
 use futures::stream::FuturesUnordered;
 use tokio_stream::StreamExt as _;
+use tracing::Level;
 use tracing::debug;
 use tracing::enabled;
 use tracing::trace;
-use tracing::Level;
 
 use crate::Docker;
 use crate::Error;

--- a/crankshaft-engine/Cargo.toml
+++ b/crankshaft-engine/Cargo.toml
@@ -14,6 +14,7 @@ bollard.workspace = true
 crankshaft-config = { path = "../crankshaft-config", version = "0.1.0" }
 crankshaft-docker = { path = "../crankshaft-docker", version = "0.1.0" }
 eyre.workspace = true
+fastbloom.workspace = true
 futures.workspace = true
 indexmap.workspace = true
 indicatif.workspace = true

--- a/crankshaft-engine/src/lib.rs
+++ b/crankshaft-engine/src/lib.rs
@@ -3,8 +3,8 @@
 use std::time::Duration;
 
 use crankshaft_config::backend::Config;
-use futures::stream::FuturesUnordered;
 use futures::StreamExt;
+use futures::stream::FuturesUnordered;
 use indexmap::IndexMap;
 use indicatif::ProgressBar;
 use indicatif::ProgressStyle;
@@ -15,9 +15,9 @@ pub mod task;
 
 pub use task::Task;
 
+use crate::service::Runner;
 use crate::service::runner::Backend;
 use crate::service::runner::TaskHandle;
-use crate::service::Runner;
 
 /// The top-level result returned within the engine.
 ///

--- a/crankshaft-engine/src/service/name.rs
+++ b/crankshaft-engine/src/service/name.rs
@@ -1,36 +1,123 @@
 //! Name generation services.
 
+use fastbloom::BloomFilter;
 use rand::rngs::ThreadRng;
-use rand::Rng as _;
+use rand::Rng;
 
 /// A name generator.
 pub trait Generator {
     /// Generates a new name.
-    fn generate(&self) -> String;
+    fn generate(&mut self, rng: &mut impl Rng) -> String;
 }
 
-/// An alphanumeric name generator.
-pub struct Alphanumeric {
+/// A unique alphanumeric name generator.
+#[derive(Debug)]
+pub struct UniqueAlphanumeric {
     /// The length of the randomized portion of the name.
     length: usize,
+    /// Bloom filter responsible for ensuring uniqueness of these names
+    bloom_filter: BloomFilter,
 }
 
-impl Default for Alphanumeric {
-    fn default() -> Self {
-        Self { length: 12 }
+impl Generator for UniqueAlphanumeric {
+    fn generate(&mut self, rng: &mut impl Rng) -> String {
+        loop {
+            let random: String = rng
+                .sample_iter(&rand::distributions::Alphanumeric)
+                .take(self.length)
+                .map(char::from)
+                .collect();
+
+            if !self.bloom_filter.contains(&random) {
+                self.bloom_filter.insert(&random);
+                return random;
+            }
+        }
     }
 }
 
-impl Generator for Alphanumeric {
-    fn generate(&self) -> String {
+impl UniqueAlphanumeric {
+    /// Default construction for a UniqueAlphanumeric generator with a given
+    /// estimated amount of generations it will need to complete.
+    pub fn default_with_expected_generations(expected: usize) -> Self {
+        Self {
+            length: 12,
+            bloom_filter: BloomFilter::with_false_pos(0.001).expected_items(expected),
+        }
+    }
+}
+
+/// An iterator over some generic generator
+#[derive(Debug)]
+pub struct GeneratorIterator<G: Generator> {
+    /// The underlying generator
+    generator: G,
+
+    /// The buffer holding generated data
+    buffer: Vec<String>,
+}
+
+impl<G: Generator> Iterator for GeneratorIterator<G> {
+    type Item = String;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(pregenerated) = self.buffer.pop() {
+            Some(pregenerated)
+        } else {
+            self.rehydrate();
+            self.buffer.pop()
+        }
+    }
+}
+
+impl<G: Generator> GeneratorIterator<G> {
+    /// Creates a new [`GeneratorIterator`] with the provided capacity.
+    pub fn new(generator: G, capacity: usize) -> Self {
+        Self {
+            generator,
+            buffer: Vec::with_capacity(capacity),
+        }
+    }
+
+    /// Rehydrates the underlying buffer by repeatedly generating unique
+    /// alphanumeric strings.
+    fn rehydrate(&mut self) {
         let mut rng = ThreadRng::default();
+        for _ in 0..self.buffer.capacity() {
+            let generated = self.generator.generate(&mut rng);
+            self.buffer.push(generated);
+        }
+    }
+}
 
-        let random: String = (&mut rng)
-            .sample_iter(&rand::distributions::Alphanumeric)
-            .take(self.length) // Generate 12 alphanumeric characters
-            .map(char::from)
-            .collect();
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
 
-        format!("job-{}", random)
+    use super::GeneratorIterator;
+    use super::UniqueAlphanumeric;
+
+    #[test]
+    fn unique_alphanumeric_generator_is_truly_unique() {
+        let alphanumeric: UniqueAlphanumeric =
+            UniqueAlphanumeric::default_with_expected_generations(100_000);
+        let mut generator: GeneratorIterator<_> = GeneratorIterator::new(alphanumeric, 100_000);
+        let _ = generator.next();
+        let unique = HashSet::<&String>::from_iter(generator.buffer.iter());
+
+        assert_eq!(generator.buffer.len(), unique.len())
+    }
+
+    #[test]
+    fn unique_alphanumeric_generator_rehydrates_when_empty() {
+        let alphanumeric: UniqueAlphanumeric =
+            UniqueAlphanumeric::default_with_expected_generations(10);
+        let mut generator: GeneratorIterator<_> = GeneratorIterator::new(alphanumeric, 10);
+
+        for _ in 0..10 {
+            assert!(generator.next().is_some())
+        }
+
+        assert!(generator.next().is_some())
     }
 }

--- a/crankshaft-engine/src/service/name.rs
+++ b/crankshaft-engine/src/service/name.rs
@@ -1,8 +1,8 @@
 //! Name generation services.
 
 use fastbloom::BloomFilter;
-use rand::rngs::ThreadRng;
 use rand::Rng;
+use rand::rngs::ThreadRng;
 
 /// A name generator.
 pub trait Generator {

--- a/crankshaft-engine/src/service/runner.rs
+++ b/crankshaft-engine/src/service/runner.rs
@@ -5,11 +5,11 @@ use std::sync::Mutex;
 
 use crankshaft_config::backend::Defaults;
 use crankshaft_config::backend::Kind;
-use futures::future::join_all;
 use futures::future::BoxFuture;
+use futures::future::join_all;
 use futures::stream::FuturesUnordered;
-use tokio::sync::oneshot::Receiver;
 use tokio::sync::Semaphore;
+use tokio::sync::oneshot::Receiver;
 use tracing::trace;
 
 pub mod backend;
@@ -18,12 +18,12 @@ pub use backend::Backend;
 
 use super::name::GeneratorIterator;
 use super::name::UniqueAlphanumeric;
+use crate::Result;
+use crate::Task;
+use crate::service::runner::backend::TaskResult;
 use crate::service::runner::backend::docker;
 use crate::service::runner::backend::generic;
 use crate::service::runner::backend::tes;
-use crate::service::runner::backend::TaskResult;
-use crate::Result;
-use crate::Task;
 
 /// The size of the name buffer.
 const NAME_BUFFER_LEN: usize = 4096;
@@ -77,7 +77,10 @@ impl Runner {
             backend,
             lock: Arc::new(Semaphore::new(max_tasks)),
             tasks: Default::default(),
-            name_generator: Arc::new(Mutex::new(GeneratorIterator::new(generator, NAME_BUFFER_LEN))),
+            name_generator: Arc::new(Mutex::new(GeneratorIterator::new(
+                generator,
+                NAME_BUFFER_LEN,
+            ))),
         })
     }
 

--- a/crankshaft-engine/src/service/runner/backend/docker.rs
+++ b/crankshaft-engine/src/service/runner/backend/docker.rs
@@ -7,16 +7,16 @@ use bollard::secret::MountTypeEnum;
 use crankshaft_config::backend::docker::Config;
 use crankshaft_docker::Docker;
 use eyre::Context;
-use futures::future::BoxFuture;
-use futures::stream::FuturesUnordered;
 use futures::FutureExt;
 use futures::StreamExt;
+use futures::future::BoxFuture;
+use futures::stream::FuturesUnordered;
 use nonempty::NonEmpty;
 use tempfile::TempDir;
 
-use crate::service::runner::backend::TaskResult;
 use crate::Result;
 use crate::Task;
+use crate::service::runner::backend::TaskResult;
 
 /// The working dir name inside the docker container
 pub const WORKDIR: &str = "/workdir";

--- a/crankshaft-engine/src/service/runner/backend/generic.rs
+++ b/crankshaft-engine/src/service/runner/backend/generic.rs
@@ -6,20 +6,20 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use crankshaft_config::backend::generic::Config;
 use crankshaft_config::backend::Defaults;
+use crankshaft_config::backend::generic::Config;
 use eyre::Context as _;
-use futures::future::BoxFuture;
 use futures::FutureExt;
+use futures::future::BoxFuture;
 use nonempty::NonEmpty;
 use regex::Regex;
 use tracing::warn;
 
-use crate::service::runner::backend::generic::driver::Driver;
-use crate::service::runner::backend::TaskResult;
-use crate::task::Resources;
 use crate::Result;
 use crate::Task;
+use crate::service::runner::backend::TaskResult;
+use crate::service::runner::backend::generic::driver::Driver;
+use crate::task::Resources;
 
 pub mod driver;
 

--- a/crankshaft-engine/src/service/runner/backend/generic/driver.rs
+++ b/crankshaft-engine/src/service/runner/backend/generic/driver.rs
@@ -10,13 +10,13 @@ use std::process::Output;
 use std::sync::Arc;
 use std::time::Duration;
 
-use crankshaft_config::backend::generic::driver::ssh;
 use crankshaft_config::backend::generic::driver::Config;
 use crankshaft_config::backend::generic::driver::Locale;
 use crankshaft_config::backend::generic::driver::Shell;
-use eyre::bail;
+use crankshaft_config::backend::generic::driver::ssh;
 use eyre::Context as _;
 use eyre::Result;
+use eyre::bail;
 use rand::Rng as _;
 use ssh2::Channel;
 use ssh2::Session;

--- a/crankshaft-engine/src/service/runner/backend/tes.rs
+++ b/crankshaft-engine/src/service/runner/backend/tes.rs
@@ -15,14 +15,14 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use crankshaft_config::backend::tes::Config;
-use futures::future::BoxFuture;
 use futures::FutureExt as _;
+use futures::future::BoxFuture;
 use nonempty::NonEmpty;
-use tes::v1::client::tasks::View;
 use tes::v1::Client;
+use tes::v1::client::tasks::View;
 
-use crate::service::runner::backend::TaskResult;
 use crate::Task;
+use crate::service::runner::backend::TaskResult;
 
 /// A backend driven by the Task Execution Service (TES) schema.
 #[derive(Debug)]

--- a/crankshaft-engine/src/task.rs
+++ b/crankshaft-engine/src/task.rs
@@ -51,6 +51,11 @@ impl Task {
         self.name.as_deref()
     }
 
+    /// Sets a task's name regardless of if it previously existed or not
+    pub fn set_name(&mut self, name: String) {
+        self.name = Some(name)
+    }
+
     /// Gets the description of the task (if it exists).
     pub fn description(&self) -> Option<&str> {
         self.description.as_deref()

--- a/crankshaft-engine/src/task/builder.rs
+++ b/crankshaft-engine/src/task/builder.rs
@@ -2,11 +2,11 @@
 
 use nonempty::NonEmpty;
 
+use crate::Task;
 use crate::task::Execution;
 use crate::task::Input;
 use crate::task::Output;
 use crate::task::Resources;
-use crate::Task;
 
 /// An error related to a [`Builder`].
 #[derive(Debug)]

--- a/crankshaft-engine/src/task/input/builder.rs
+++ b/crankshaft-engine/src/task/input/builder.rs
@@ -1,8 +1,8 @@
 //! Builders for an [`Input`].
 
+use crate::task::Input;
 use crate::task::input::Contents;
 use crate::task::input::Type;
-use crate::task::Input;
 
 /// An error related to a [`Builder`].
 #[derive(Debug)]

--- a/crankshaft-engine/src/task/output/builder.rs
+++ b/crankshaft-engine/src/task/output/builder.rs
@@ -2,8 +2,8 @@
 
 use url::Url;
 
-use crate::task::output::Type;
 use crate::task::Output;
+use crate::task::output::Type;
 
 /// An error related to a [`Builder`].
 #[derive(Debug)]

--- a/crankshaft/examples/docker.rs
+++ b/crankshaft/examples/docker.rs
@@ -7,21 +7,21 @@
 use std::io::Write;
 
 use clap::Parser;
-use crankshaft::config::backend::docker::Config;
+use crankshaft::Engine;
 use crankshaft::config::backend::Kind;
-use crankshaft::engine::task::input;
+use crankshaft::config::backend::docker::Config;
+use crankshaft::engine::Task;
 use crankshaft::engine::task::Execution;
 use crankshaft::engine::task::Input;
-use crankshaft::engine::Task;
-use crankshaft::Engine;
+use crankshaft::engine::task::input;
 use eyre::Context;
 use eyre::Result;
 use tempfile::NamedTempFile;
 use tracing::info;
+use tracing_subscriber::EnvFilter;
 use tracing_subscriber::fmt;
 use tracing_subscriber::layer::SubscriberExt as _;
 use tracing_subscriber::util::SubscriberInitExt as _;
-use tracing_subscriber::EnvFilter;
 
 #[derive(Debug, Parser)]
 #[allow(missing_docs)]

--- a/crankshaft/examples/driver.rs
+++ b/crankshaft/examples/driver.rs
@@ -10,10 +10,10 @@ use clap::Parser;
 use crankshaft::config::backend::generic::driver::Config;
 use crankshaft::engine::service::runner::backend::generic::driver::Driver;
 use eyre::Result;
+use tracing_subscriber::EnvFilter;
 use tracing_subscriber::fmt;
 use tracing_subscriber::layer::SubscriberExt as _;
 use tracing_subscriber::util::SubscriberInitExt as _;
-use tracing_subscriber::EnvFilter;
 
 #[derive(Parser)]
 #[allow(missing_docs)]

--- a/crankshaft/examples/lsf.rs
+++ b/crankshaft/examples/lsf.rs
@@ -5,18 +5,18 @@
 //! `cargo run --release --example lsf`
 
 use clap::Parser;
-use crankshaft::engine::task::Execution;
-use crankshaft::engine::Task;
 use crankshaft::Config;
 use crankshaft::Engine;
+use crankshaft::engine::Task;
+use crankshaft::engine::task::Execution;
 use eyre::Context as _;
 use eyre::ContextCompat as _;
 use eyre::Result;
 use tracing::info;
+use tracing_subscriber::EnvFilter;
 use tracing_subscriber::fmt;
 use tracing_subscriber::layer::SubscriberExt as _;
 use tracing_subscriber::util::SubscriberInitExt as _;
-use tracing_subscriber::EnvFilter;
 
 #[derive(Debug, Parser)]
 #[allow(missing_docs)]

--- a/crankshaft/examples/tes.rs
+++ b/crankshaft/examples/tes.rs
@@ -9,19 +9,19 @@
 //! header with that token.
 
 use clap::Parser;
-use crankshaft::config::backend::tes::http;
-use crankshaft::config::backend::tes::Config;
-use crankshaft::config::backend::Kind;
-use crankshaft::engine::task::Execution;
-use crankshaft::engine::Task;
 use crankshaft::Engine;
+use crankshaft::config::backend::Kind;
+use crankshaft::config::backend::tes::Config;
+use crankshaft::config::backend::tes::http;
+use crankshaft::engine::Task;
+use crankshaft::engine::task::Execution;
 use eyre::Context;
 use eyre::Result;
 use tracing::info;
+use tracing_subscriber::EnvFilter;
 use tracing_subscriber::fmt;
 use tracing_subscriber::layer::SubscriberExt as _;
 use tracing_subscriber::util::SubscriberInitExt as _;
-use tracing_subscriber::EnvFilter;
 use url::Url;
 
 #[derive(Debug, Parser)]

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -10,6 +10,6 @@ newline_style = "Unix"
 normalize_comments = true
 normalize_doc_attributes = true
 reorder_impl_items = true
+style_edition = "2024"
 use_field_init_shorthand = true
 wrap_comments = true
-version = "Two"


### PR DESCRIPTION
_Describe the problem or feature in addition to a link to the issues._
This PR Aims to ensure the Alphanumeric Generator for Docker names generates truly unique names to avoid reusing a name in use. It uses a bloom filter under the hood to ensure this. The generator also now holds a buffer of pregenerated names as to reduce `thread_rng` creation. 

Before submitting this PR, please make sure:

- [X] You have added a few sentences describing the PR here.
- [X] You have added yourself or the appropriate individual as the assignee.
- [X] You have added at least one relevant code reviewer to the PR.
- [X] Your code builds clean without any errors or warnings.
- [X] You have added tests (when appropriate).
- [X] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [ ] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [X] Your commit messages follow the [conventional commit] style.


[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
