### PR TITLE
Fix examples link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,7 @@ cargo add crankshaft
 ```
 
 Once you've added `crankshaft` to your dependencies, you should head over to the
-[`/examples`](https://github.com/stjude-rust-labs/crankshaft/tree/main/crankshaft/examples)
-to see how you can use the library in your projects.
+[`examples`](./examples) to see how you can use the library in your projects.
 
 ## 🖥️ Development
 


### PR DESCRIPTION
The examples link in the README.md was broken because it had an extra `crankshaft`.

Replaced with a relative link, but it could also be replaced with `https://github.com/stjude-rust-labs/crankshaft/tree/main/examples` if you wanted to use an absolute link.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [ ] You have added yourself or the appropriate individual as the assignee.
- [ ] You have added at least one relevant code reviewer to the PR.
- [ ] Your code builds clean without any errors or warnings.
- [ ] You have added tests (when appropriate).
- [ ] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [ ] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [ ] Your commit messages follow the [conventional commit] style.


