### PR TITLE
revise: removes multiple `#[builder(into)]` declarations

### DIFF
--- a/crankshaft-config/CHANGELOG.md
+++ b/crankshaft-config/CHANGELOG.md
@@ -13,4 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-* Use `thiserror` for custom error types ([#8](https://github.com/stjude-rust-labs/crankshaft/pull/8)).
+* Use `thiserror` for custom error types
+  ([#8](https://github.com/stjude-rust-labs/crankshaft/pull/8)).
+* Removes `#[builder(into)]` for numerical types
+  ([#10](https://github.com/stjude-rust-labs/crankshaft/pull/10)).

--- a/crankshaft-config/src/backend.rs
+++ b/crankshaft-config/src/backend.rs
@@ -28,7 +28,6 @@ pub struct Config {
     kind: Kind,
 
     /// The maximum number of concurrent tasks that can run.
-    #[builder(into)]
     max_tasks: usize,
 
     /// The execution defaults.

--- a/crankshaft-config/src/backend/generic.rs
+++ b/crankshaft-config/src/backend/generic.rs
@@ -78,7 +78,6 @@ pub struct Config {
     monitor: String,
 
     /// The frequency in seconds that the job status will be queried.
-    #[builder(into)]
     monitor_frequency: Option<u64>,
 
     /// The script used to kill a job.

--- a/crankshaft-config/src/backend/generic/driver.rs
+++ b/crankshaft-config/src/backend/generic/driver.rs
@@ -30,7 +30,6 @@ pub struct Config {
     shell: Option<Shell>,
 
     /// The maximum number of attempts to try a command execution.
-    #[builder(into)]
     max_attempts: Option<u32>,
 }
 

--- a/crankshaft-config/src/backend/generic/driver/ssh.rs
+++ b/crankshaft-config/src/backend/generic/driver/ssh.rs
@@ -14,7 +14,6 @@ pub struct Config {
     username: Option<String>,
 
     /// A port.
-    #[builder(into)]
     port: usize,
 }
 

--- a/crankshaft-docker/CHANGELOG.md
+++ b/crankshaft-docker/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-* Use `thiserror` for custom error types ([#8](https://github.com/stjude-rust-labs/crankshaft/pull/8)).
-* Separate `program` from `args` in container builder ([#8](https://github.com/stjude-rust-labs/crankshaft/pull/8)).
-* Replaced `attached` with separate stdout and stderr attach flags ([#8](https://github.com/stjude-rust-labs/crankshaft/pull/8)).
+* Use `thiserror` for custom error types
+  ([#8](https://github.com/stjude-rust-labs/crankshaft/pull/8)).
+* Separate `program` from `args` in container builder
+  ([#8](https://github.com/stjude-rust-labs/crankshaft/pull/8)).
+* Replaced `attached` with separate stdout and stderr attach flags
+  ([#8](https://github.com/stjude-rust-labs/crankshaft/pull/8)).

--- a/crankshaft-engine/CHANGELOG.md
+++ b/crankshaft-engine/CHANGELOG.md
@@ -26,3 +26,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Input::builder`.
 * Better handling for URL contents in inputs.
 * Swaps out most of the bespoke builders for `bon`.
+* Removes `#[builder(into)]` for numerical types
+  ([#10](https://github.com/stjude-rust-labs/crankshaft/pull/10)).

--- a/crankshaft-engine/src/task/resources.rs
+++ b/crankshaft-engine/src/task/resources.rs
@@ -12,7 +12,6 @@ use crankshaft_config::backend::Defaults;
 #[builder(builder_type = Builder)]
 pub struct Resources {
     /// The number of CPU cores requested.
-    #[builder(into)]
     cpu: Option<usize>,
 
     /// Whether or not the task may use preemptible resources.
@@ -20,11 +19,9 @@ pub struct Resources {
     preemptible: Option<bool>,
 
     /// The requested random access memory size in gigabytes.
-    #[builder(into)]
     ram: Option<f64>,
 
     /// The requested disk size in gigabytes.
-    #[builder(into)]
     disk: Option<f64>,
 
     /// The associated compute zones.


### PR DESCRIPTION
The author of `bon` helpfully pointed out [here](https://github.com/stjude-rust-labs/crankshaft/commit/4ad7e01876857e7a8580819ce477bdf6641898af#r152203674) that we shouldn't be using `[builder(into)]` for numeric types because it ambiguates what type the numbers should resolve to.

<!--
When creating a pull request, you should uncomment the section below that
describes the type of pull request you are submitting.
-->

<!-- START SECTION: all pull requests

_Describe the problem or feature in addition to a link to the issues._

Before submitting this PR, please make sure:

- [ ] You have added a few sentences describing the PR here.
- [ ] You have added yourself or the appropriate individual as the assignee.
- [ ] You have added at least one relevant code reviewer to the PR.
- [ ] Your code builds clean without any errors or warnings.
- [ ] You have added tests (when appropriate).
- [ ] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [ ] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [ ] Your commit messages follow the [conventional commit] style.

END SECTION -->

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
