### PR TITLE
feat: improve the Docker backend.

### DIFF
--- a/crankshaft-docker/src/bin/docker-driver.rs
+++ b/crankshaft-docker/src/bin/docker-driver.rs
@@ -65,11 +65,9 @@ enum Command {
     /// existing).
     EnsureImage {
         /// The name of the image.
+        ///
+        /// If a tag is not specified, a default tag of `latest` is used.
         image: String,
-
-        #[arg(short, long, default_value = "latest")]
-        /// The tag for the image.
-        tag: String,
     },
 
     /// Lists all images.
@@ -156,8 +154,8 @@ async fn run(args: Args) -> Result<()> {
                 container.remove().await?;
             }
         }
-        Command::EnsureImage { image, tag } => {
-            docker.ensure_image(image, tag).await?;
+        Command::EnsureImage { image } => {
+            docker.ensure_image(image).await?;
         }
         Command::ListImages => {
             docker.list_images().await?;

--- a/crankshaft-docker/src/container/builder.rs
+++ b/crankshaft-docker/src/container/builder.rs
@@ -103,7 +103,7 @@ impl Builder {
     /// Sets multiple environment variables.
     pub fn envs(
         mut self,
-        variables: impl Iterator<Item = (impl Into<String>, impl Into<String>)>,
+        variables: impl IntoIterator<Item = (impl Into<String>, impl Into<String>)>,
     ) -> Self {
         self.env
             .extend(variables.into_iter().map(|(k, v)| (k.into(), v.into())));

--- a/crankshaft-docker/src/lib.rs
+++ b/crankshaft-docker/src/lib.rs
@@ -75,12 +75,15 @@ impl Docker {
 
     /// Ensures that an image exists in the Docker daemon.
     ///
+    /// If the image does not specify a tag, a default tag of `latest` will be
+    /// used.
+    ///
     /// It does this by:
     ///
     /// * Confirming that the image already exists there, or
     /// * Pulling the image from the remote repository.
-    pub async fn ensure_image(&self, name: impl AsRef<str>, tag: impl AsRef<str>) -> Result<()> {
-        ensure_image(self, name, tag).await
+    pub async fn ensure_image(&self, image: impl AsRef<str>) -> Result<()> {
+        ensure_image(self, image).await
     }
 
     /// Removes an image from the Docker daemon.

--- a/crankshaft-engine/CHANGELOG.md
+++ b/crankshaft-engine/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added support for bind mounting inputs to the Docker backend ([#12](https://github.com/stjude-rust-labs/crankshaft/pull/12)).
 * Added cancellation support to the engine and ctrl-c handling in the examples (#[11](https://github.com/stjude-rust-labs/crankshaft/pull/11)).
 * Added support for Docker Swarm in the docker backend (#[11](https://github.com/stjude-rust-labs/crankshaft/pull/11)).
 * Adds the initial version of the crate.
@@ -32,3 +33,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Swaps out most of the bespoke builders for `bon`.
 * Removes `#[builder(into)]` for numerical types
   ([#10](https://github.com/stjude-rust-labs/crankshaft/pull/10)).
+
+### Fixed
+
+* The Docker backend now ensures task execution images are present locally
+  before creating any containers ([#12](https://github.com/stjude-rust-labs/crankshaft/pull/12)).

--- a/examples/src/docker/main.rs
+++ b/examples/src/docker/main.rs
@@ -64,7 +64,7 @@ async fn run(args: Args, token: CancellationToken) -> Result<()> {
                         .display()
                         .to_string(),
                 )
-                .image("ubuntu")
+                .image("alpine")
                 .program("echo")
                 .args([String::from("hello, world!")])
                 .build(),

--- a/examples/src/lsf/main.rs
+++ b/examples/src/lsf/main.rs
@@ -85,7 +85,7 @@ async fn run(args: Args, token: CancellationToken) -> Result<()> {
                         .display()
                         .to_string(),
                 )
-                .image("ubuntu")
+                .image("alpine")
                 .program("echo")
                 .args([String::from("hello, world!")])
                 .build(),

--- a/examples/src/tes/main.rs
+++ b/examples/src/tes/main.rs
@@ -97,7 +97,7 @@ async fn run(args: Args, token: CancellationToken) -> Result<()> {
                         .display()
                         .to_string(),
                 )
-                .image("ubuntu")
+                .image("alpine")
                 .program("echo")
                 .args([String::from("hello, world!")])
                 .build(),


### PR DESCRIPTION
This PR includes:

* add support for specifying inputs by host file path.
* implement inputs as bind mounts rather than files uploaded to the container.
* implement mounts for tasks that use services rather than containers.
* make the Docker backend ensure the task execution's image exists locally before creating the container or service.
* use `alpine` for the examples as it is smaller than `ubuntu`.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
