### PR TITLE
revise: improvements to configuration and related elements

### DIFF
--- a/crankshaft-config/src/backend.rs
+++ b/crankshaft-config/src/backend.rs
@@ -62,3 +62,27 @@ impl Config {
         (self.name, self.kind, self.max_tasks, self.defaults)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generic() {
+        let config = Config::builder()
+            .name("generic")
+            .kind(Kind::Generic(generic::demo()))
+            .max_tasks(10)
+            .defaults(Defaults::builder().cpu(1.0).ram(16.0).disk(250.0).build())
+            .build();
+
+        assert_eq!(config.name(), "generic");
+        assert!(matches!(config.kind().as_generic(), Some(_)));
+        assert_eq!(config.max_tasks(), 10);
+
+        let defaults = config.defaults.unwrap();
+        assert_eq!(defaults.cpu().unwrap(), 1.0);
+        assert_eq!(defaults.ram().unwrap(), 16.0);
+        assert_eq!(defaults.disk().unwrap(), 250.0);
+    }
+}

--- a/crankshaft-config/src/backend/defaults.rs
+++ b/crankshaft-config/src/backend/defaults.rs
@@ -1,24 +1,29 @@
 //! Configuration options related to the default execution resources
 //! requested/required.
 
+use bon::Builder;
 use serde::Deserialize;
 use serde::Serialize;
 
 /// Default resource requests.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Builder, Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
+#[builder(builder_type = Builder)]
 pub struct Defaults {
     /// The number of CPUs to use during execution.
-    cpu: Option<usize>,
+    ///
+    /// Partial CPU requests are supported but not always respected depending on
+    /// the backend.
+    cpu: Option<f64>,
 
-    /// The amount of RAM (in GB) to use during execution.
+    /// The amount of RAM (in GiB) to use during execution.
     ///
     /// This is a float because RAM can be allocated more granularly than in
     /// gigabytes. These may be rounded to any level of precision that is
     /// required for a particular environment.
     ram: Option<f64>,
 
-    /// The amount of disk (in GB) to use during execution.
+    /// The amount of disk (in GiB) to use during execution.
     ///
     /// This is a float because disks can be allocated more granularly than in
     /// gigabytes. These may be rounded to any level of precision that is
@@ -28,7 +33,7 @@ pub struct Defaults {
 
 impl Defaults {
     /// Gets the number of CPUs.
-    pub fn cpu(&self) -> Option<usize> {
+    pub fn cpu(&self) -> Option<f64> {
         self.cpu
     }
 

--- a/crankshaft-config/src/backend/generic.rs
+++ b/crankshaft-config/src/backend/generic.rs
@@ -189,22 +189,47 @@ impl Config {
     }
 }
 
+/// A generic configuration used during testing.
+#[cfg(test)]
+pub(crate) fn demo() -> Config {
+    Config::builder()
+        .driver(driver::demo())
+        .submit("echo 'submitting'")
+        .monitor("echo 'monitoring'")
+        .kill("echo 'killing'")
+        .build()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn the_placeholder_regex_unwraps() {
-        let _ = PLACEHOLDER_REGEX;
+    fn regexes() {
+        // Ensure that the whitespace regex unwraps.
+        let _ = std::hint::black_box(&WHITESPACE_REGEX);
+
+        // Ensure that the placeholder regex unwraps.
+        let _ = std::hint::black_box(&PLACEHOLDER_REGEX);
     }
 
     #[test]
-    fn replacement_works() -> Result<(), Box<dyn std::error::Error>> {
+    fn replacement() {
         let mut replacements = HashMap::new();
         replacements.insert("foo".into(), "bar".into());
 
         assert_eq!(substitute("hello, ~{foo}", &replacements), "hello, bar");
+    }
 
-        Ok(())
+    #[test]
+    fn demo() {
+        let demo = super::demo();
+        assert_eq!(demo.driver(), &driver::demo());
+        assert_eq!(demo.submit(), "echo 'submitting'");
+        assert!(demo.job_id_regex().is_none());
+        assert_eq!(demo.monitor(), "echo 'monitoring'");
+        assert!(demo.monitor_frequency().is_none());
+        assert_eq!(demo.kill(), "echo 'killing'");
+        assert!(demo.attributes().is_empty());
     }
 }

--- a/crankshaft-config/src/backend/generic/driver/locale.rs
+++ b/crankshaft-config/src/backend/generic/driver/locale.rs
@@ -6,7 +6,7 @@ use serde::Serialize;
 use crate::backend::generic::driver::ssh;
 
 /// The environment from which jobs are executed.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize)]
 #[serde(tag = "kind", rename_all = "PascalCase")]
 pub enum Locale {
     /// Local execution.

--- a/crankshaft-config/src/backend/generic/driver/shell.rs
+++ b/crankshaft-config/src/backend/generic/driver/shell.rs
@@ -9,7 +9,7 @@ use serde::Serialize;
 const ENV_PATH: &str = "/usr/bin/env";
 
 /// A shell within which to run commands.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum Shell {
     /// Run commands using `bash`.

--- a/crankshaft-config/src/backend/generic/driver/ssh.rs
+++ b/crankshaft-config/src/backend/generic/driver/ssh.rs
@@ -5,7 +5,7 @@ use serde::Deserialize;
 use serde::Serialize;
 
 /// Configuration related to SSH.
-#[derive(Builder, Clone, Debug, Deserialize, Serialize)]
+#[derive(Builder, Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
 #[builder(builder_type = Builder)]
 pub struct Config {

--- a/crankshaft-config/src/lib.rs
+++ b/crankshaft-config/src/lib.rs
@@ -141,7 +141,7 @@ mod tests {
         let backend = &config.backends[1];
 
         assert_eq!(backend.name(), "quux");
-        assert_eq!(backend.defaults().unwrap().cpu(), Some(1));
+        assert_eq!(backend.defaults().unwrap().cpu(), Some(1.0));
         assert_eq!(backend.defaults().unwrap().ram(), Some(1.0));
     }
 }

--- a/crankshaft-engine/src/service/runner/backend/generic/driver.rs
+++ b/crankshaft-engine/src/service/runner/backend/generic/driver.rs
@@ -330,8 +330,9 @@ async fn run_ssh_command(
 
         // Create a new channel with which to communicate with the host.
         trace!("creating a new session-based channel");
-        let mut channel = channel_session_with_backoff(&session, max_attempts)
-            .context("creating a new session-based channel")?;
+        let mut channel =
+            channel_session_with_backoff(&session, max_attempts.unwrap_or_default().inner())
+                .context("creating a new session-based channel")?;
 
         // Send a command across the channel.
         trace!("sending the execution command");

--- a/crankshaft-engine/src/task/resources.rs
+++ b/crankshaft-engine/src/task/resources.rs
@@ -12,16 +12,19 @@ use crankshaft_config::backend::Defaults;
 #[builder(builder_type = Builder)]
 pub struct Resources {
     /// The number of CPU cores requested.
-    cpu: Option<usize>,
+    ///
+    /// Partial CPU requests are supported but not always respected depending on
+    /// the backend.
+    cpu: Option<f64>,
 
     /// Whether or not the task may use preemptible resources.
     #[builder(into)]
     preemptible: Option<bool>,
 
-    /// The requested random access memory size in gigabytes.
+    /// The requested random access memory size (in GiB).
     ram: Option<f64>,
 
-    /// The requested disk size in gigabytes.
+    /// The requested disk size (in GiB).
     disk: Option<f64>,
 
     /// The associated compute zones.
@@ -30,8 +33,8 @@ pub struct Resources {
 }
 
 impl Resources {
-    /// A number of CPU cores.
-    pub fn cpu(&self) -> Option<usize> {
+    /// The number of CPU cores.
+    pub fn cpu(&self) -> Option<f64> {
         self.cpu
     }
 
@@ -118,7 +121,7 @@ impl Resources {
 impl Default for Resources {
     fn default() -> Self {
         Self {
-            cpu: Some(1),
+            cpu: Some(1.0),
             preemptible: Some(false),
             ram: Some(2.0),
             disk: Some(8.0),


### PR DESCRIPTION
This pull request adds the following:

- Changes the internal representation `cpu` to be an `f64` instead of a `usize` (to represent CPU slices).
- Changes the memory representation from gigabytes to gibibytes (@peterhuene, does this affect any of your Docker work)?
- Adds `#[derive(PartialEq)]` to various parts of the configuration.
- Fixes an issue where some regexes weren't actually being tested (because the compiler was eliding the evaluating).
- Extends the testing around configuration in general.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
