### PR TITLE
fix: pass environment variables for the Docker backend.

### DIFF
--- a/crankshaft-docker/CHANGELOG.md
+++ b/crankshaft-docker/CHANGELOG.md
@@ -24,4 +24,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* Fixed environment variables not being set in containers ([#18](https://github.com/stjude-rust-labs/crankshaft/pull/18))
 * Fixed a non-zero exit code from a container being treated as a wait error ([#16](https://github.com/stjude-rust-labs/crankshaft/pull/16)).

--- a/crankshaft-engine/src/service/runner/backend/docker.rs
+++ b/crankshaft-engine/src/service/runner/backend/docker.rs
@@ -393,6 +393,7 @@ impl crate::Backend for Backend {
                         .image(execution.image())
                         .program(execution.program())
                         .args(execution.args())
+                        .envs(execution.env())
                         .resources(task.resources().map(Into::into).unwrap_or_default())
                         .attach_stdout()
                         .attach_stderr();
@@ -421,6 +422,7 @@ impl crate::Backend for Backend {
                         .image(execution.image())
                         .program(execution.program())
                         .args(execution.args())
+                        .envs(execution.env())
                         .attach_stdout()
                         .attach_stderr()
                         .host_config(HostConfig {


### PR DESCRIPTION
The Docker backend was not passing along any requested environment variables to service or container creation.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
