### PR TITLE
Fix cargo release build issue by updating bollard dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,4 +92,4 @@ broken_intra_doc_links = "warn"
 missing_docs_in_private_items = "warn"
 
 [patch.crates-io]
-bollard = { git = "https://github.com/peterhuene/bollard", branch = "nodes-api" }
+bollard = { git = "https://github.com/fussybeaver/bollard", branch = "master" }


### PR DESCRIPTION
This PR fixes the cargo build issue due to the missing `nodes-api` branch in the `bollard` dependency.

- Updated `Cargo.toml` to use the Official `bollard` branch/version.
- Verified successful compilation with `cargo build --release`.
- Passed all tests

Fixes #22 

@claymcleod 