### PR TITLE
Fix: Add correct bollard patch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,4 +92,4 @@ broken_intra_doc_links = "warn"
 missing_docs_in_private_items = "warn"
 
 [patch.crates-io]
-bollard = { git = "https://github.com/peterhuene/bollard", branch = "nodes-api" }
+bollard = { git = "https://github.com/fussybeaver/bollard", rev = "bf2b9244264bd2a8970b9963c6f27cd34fec4168" }

--- a/crankshaft/CHANGELOG.md
+++ b/crankshaft/CHANGELOG.md
@@ -14,3 +14,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * Updated dependencies to latest ([#17](https://github.com/stjude-rust-labs/crankshaft/pull/17)).
+
+* Fixed bollard dependency by locking it to commit bf2b9244264bd2a8970b9963c6f27cd34fec4168 from the master branch, due to the removal of the nodes-api branch.


### PR DESCRIPTION
This PR addresses an issue with the bollard dependency where the previously referenced branch nodes-api no longer exists. To resolve this, the dependency has been updated to point to a specific commit in the master branch of the bollard repository.
Fixes: #22

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [ ] You have added yourself or the appropriate individual as the assignee.
- [ ] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
