### PR TITLE
revise: updates `bollard` to `0.19.0-rc.1`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,12 @@ license = "MIT OR Apache-2.0"
 edition = "2021"
 authors = ["The Rust WDL project developers"]
 homepage = "https://github.com/stjude-rust-labs/crankshaft"
-repository = "https://github.com/stjude-rust-labs/wdl"
+repository = "https://github.com/stjude-rust-labs/crankshaft"
 rust-version = "1.83.0"
 
 [workspace.dependencies]
 async-trait = "0.1.86"
-bollard = "0.18.1"
+bollard = "0.19.0-rc1"
 bon = "3.3.2"
 clap = { version = "4.5.30", features = ["derive"] }
 clap-verbosity-flag = "3.0.2"
@@ -90,6 +90,3 @@ broken_intra_doc_links = "warn"
 
 [workspace.lints.clippy]
 missing_docs_in_private_items = "warn"
-
-[patch.crates-io]
-bollard = { git = "https://github.com/peterhuene/bollard", branch = "nodes-api" }

--- a/crankshaft-docker/CHANGELOG.md
+++ b/crankshaft-docker/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#8](https://github.com/stjude-rust-labs/crankshaft/pull/8)).
 * Replaced `attached` with separate stdout and stderr attach flags
   ([#8](https://github.com/stjude-rust-labs/crankshaft/pull/8)).
+* Updated `bollard` to an official, upstreamed crate release
+  ([#29](https://github.com/stjude-rust-labs/crankshaft/pull/29)).
 
 ### Fixed
 

--- a/crankshaft-docker/src/bin/docker-driver.rs
+++ b/crankshaft-docker/src/bin/docker-driver.rs
@@ -91,7 +91,7 @@ async fn create_container(
     docker: Docker,
     image: impl AsRef<str>,
     tag: impl AsRef<str>,
-    name: impl AsRef<str>,
+    name: impl Into<String>,
     program: impl Into<String>,
     args: impl IntoIterator<Item = impl Into<String>>,
 ) -> Result<Container> {

--- a/crankshaft-docker/src/container/builder.rs
+++ b/crankshaft-docker/src/container/builder.rs
@@ -1,8 +1,8 @@
 //! Builders for containers.
 
 use bollard::Docker;
-use bollard::container::Config;
-use bollard::container::CreateContainerOptions;
+use bollard::models::ContainerCreateBody;
+use bollard::query_parameters::CreateContainerOptions;
 use bollard::secret::HostConfig;
 use indexmap::IndexMap;
 use tracing::warn;
@@ -125,7 +125,7 @@ impl Builder {
     /// Consumes `self` and attempts to create a Docker container.
     ///
     /// Note that the creation of a container does not start the container.
-    pub async fn try_build(self, name: impl AsRef<str>) -> Result<Container> {
+    pub async fn try_build(self, name: impl Into<String>) -> Result<Container> {
         let image = self
             .image
             .ok_or_else(|| Error::MissingBuilderField("image"))?;
@@ -141,10 +141,10 @@ impl Builder {
             .client
             .create_container(
                 Some(CreateContainerOptions {
-                    name: name.as_ref(),
+                    name: Some(name.into()),
                     ..Default::default()
                 }),
-                Config {
+                ContainerCreateBody {
                     // NOTE: even though the following fields are optional, I
                     // want _this_ struct to require the explicit designation
                     // one way or the other and not rely on the default.

--- a/crankshaft-docker/src/images.rs
+++ b/crankshaft-docker/src/images.rs
@@ -2,8 +2,9 @@
 
 use std::collections::HashMap;
 
-use bollard::image::CreateImageOptions;
-use bollard::image::ListImagesOptions;
+use bollard::query_parameters::CreateImageOptions;
+use bollard::query_parameters::ListImagesOptions;
+use bollard::query_parameters::RemoveImageOptions;
 use bollard::secret::ImageDeleteResponseItem;
 use bollard::secret::ImageSummary;
 use futures::stream::FuturesUnordered;
@@ -23,7 +24,7 @@ pub(crate) async fn list_images(docker: &Docker) -> Result<Vec<ImageSummary>> {
 
     let images = docker
         .inner()
-        .list_images(Some(ListImagesOptions::<String> {
+        .list_images(Some(ListImagesOptions {
             all: true,
             ..Default::default()
         }))
@@ -62,17 +63,17 @@ pub(crate) async fn list_images(docker: &Docker) -> Result<Vec<ImageSummary>> {
 ///
 /// * Confirming that the image already exists there, or
 /// * Pulling the image from the remote repository.
-pub(crate) async fn ensure_image(docker: &Docker, image: impl AsRef<str>) -> Result<()> {
-    let image = image.as_ref();
+pub(crate) async fn ensure_image(docker: &Docker, image: impl Into<String>) -> Result<()> {
+    let image = image.into();
 
     debug!("ensuring image `{image}` exists locally");
 
     let mut filters = HashMap::new();
-    filters.insert("reference", vec![image]);
+    filters.insert(String::from("reference"), vec![image.clone()]);
     let results = docker
         .inner()
         .list_images(Some(ListImagesOptions {
-            filters,
+            filters: Some(filters),
             ..Default::default()
         }))
         .await
@@ -94,8 +95,12 @@ pub(crate) async fn ensure_image(docker: &Docker, image: impl AsRef<str>) -> Res
     debug!("image `{image}` does not exist locally; attempting to pull from remote");
     let mut stream = docker.inner().create_image(
         Some(CreateImageOptions {
-            from_image: image,
-            tag: if image.contains(':') { "" } else { "latest" },
+            tag: Some(if image.contains(':') {
+                String::from("")
+            } else {
+                String::from("latest")
+            }),
+            from_image: Some(image),
             ..Default::default()
         }),
         None,
@@ -153,7 +158,7 @@ pub(crate) async fn remove_image<T: AsRef<str>, U: AsRef<str>>(
     debug!("removing image: {name} ({tag})");
     let images = docker
         .inner()
-        .remove_image(name, None, None)
+        .remove_image(name, None::<RemoveImageOptions>, None)
         .await
         .map_err(Error::Docker)?;
 

--- a/crankshaft-docker/src/lib.rs
+++ b/crankshaft-docker/src/lib.rs
@@ -1,5 +1,6 @@
 //! A Docker client that uses [`bollard`].
 
+use bollard::query_parameters::ListNodesOptions;
 use bollard::secret::ImageDeleteResponseItem;
 use bollard::secret::ImageSummary;
 
@@ -82,7 +83,7 @@ impl Docker {
     ///
     /// * Confirming that the image already exists there, or
     /// * Pulling the image from the remote repository.
-    pub async fn ensure_image(&self, image: impl AsRef<str>) -> Result<()> {
+    pub async fn ensure_image(&self, image: impl Into<String>) -> Result<()> {
         ensure_image(self, image).await
     }
 
@@ -134,7 +135,10 @@ impl Docker {
     /// This method should only be called for a Docker daemon that has been
     /// joined to a swarm.
     pub async fn nodes(&self) -> Result<Vec<Node>> {
-        self.0.list_nodes::<&str>(None).await.map_err(Into::into)
+        self.0
+            .list_nodes(None::<ListNodesOptions>)
+            .await
+            .map_err(Into::into)
     }
 
     //----------------------------------------------------------------------------------

--- a/crankshaft-docker/src/service.rs
+++ b/crankshaft-docker/src/service.rs
@@ -11,11 +11,12 @@ use std::time::Duration;
 
 use bollard::Docker;
 use bollard::container::LogOutput;
-use bollard::container::LogsOptions;
-use bollard::container::WaitContainerOptions;
+use bollard::query_parameters::InspectContainerOptions;
+use bollard::query_parameters::ListTasksOptions;
+use bollard::query_parameters::LogsOptions;
+use bollard::query_parameters::WaitContainerOptions;
 use bollard::secret::ContainerWaitResponse;
 use bollard::secret::TaskState;
-use bollard::task::ListTasksOptions;
 
 mod builder;
 
@@ -77,7 +78,10 @@ impl Service {
             let tasks = self
                 .client
                 .list_tasks(Some(ListTasksOptions {
-                    filters: HashMap::from_iter([("service", vec![self.id.as_str()])]),
+                    filters: Some(HashMap::from_iter([(
+                        String::from("service"),
+                        vec![self.id.to_owned()],
+                    )])),
                 }))
                 .await
                 .map_err(Error::Docker)?;
@@ -136,7 +140,7 @@ impl Service {
                     // Wait for the container to be completed.
                     let mut wait_stream = self
                         .client
-                        .wait_container(&container_id, None::<WaitContainerOptions<&str>>);
+                        .wait_container(&container_id, None::<WaitContainerOptions>);
 
                     let mut exit_code = None;
                     if let Some(result) = wait_stream.next().await {
@@ -158,7 +162,7 @@ impl Service {
                         // Get the exit code if the wait was immediate
                         let container = self
                             .client
-                            .inspect_container(&container_id, None)
+                            .inspect_container(&container_id, None::<InspectContainerOptions>)
                             .await
                             .map_err(Error::Docker)?;
 
@@ -224,7 +228,7 @@ impl Service {
         // Attach to the logs stream.
         let stream = self.client.logs(
             &container_id,
-            Some(LogsOptions::<&str> {
+            Some(LogsOptions {
                 stdout: self.attach_stdout,
                 stderr: self.attach_stderr,
                 ..Default::default()

--- a/crankshaft-engine/src/service/runner/backend/docker.rs
+++ b/crankshaft-engine/src/service/runner/backend/docker.rs
@@ -436,7 +436,7 @@ impl crate::Backend for Backend {
 
                     let container = Arc::new(
                         builder
-                            .try_build(&name)
+                            .try_build(name.clone())
                             .await?,
                     );
 


### PR DESCRIPTION
This commit updates `bollard` to `0.19.0-rc.1`, which is the first commit that
contains @peterhuene's Nodes and Tasks API changes. This also includes some
minor updates to handling of ownership to avoid unnecessary clones (e.g., `impl
AsRef<str>` to `impl Into<String>`).

A good portion of this work was done in https://github.com/stjude-rust-labs/crankshaft/pull/28 and modified to reduce clones.

Closes https://github.com/stjude-rust-labs/crankshaft/issues/22.
Closes https://github.com/stjude-rust-labs/crankshaft/issues/24.
Closes https://github.com/stjude-rust-labs/crankshaft/issues/27.
Closes https://github.com/stjude-rust-labs/crankshaft/pull/28.

Co-authored-by: srijanmahajan <srajanmahajan1@gmail.com>

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/