### PR TITLE
fix(examples): changes target type `bin` -> `example`

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -29,15 +29,15 @@ url.workspace = true
 indicatif.workspace = true
 futures.workspace = true
 
-[[bin]]
+[[example]]
 name = "docker"
 path = "src/docker/main.rs"
 
-[[bin]]
+[[example]]
 name = "lsf"
 path = "src/lsf/main.rs"
 
-[[bin]]
+[[example]]
 name = "tes"
 path = "src/tes/main.rs"
 


### PR DESCRIPTION
The targets being `bin` type in examples causes two *very* minor problems:
1. Any tests that may be added in the future aren't picked up by the `test-examples` CI stage - recent output: [`warning: target filter `examples` specified, but no targets matched; this is a no-op`](https://github.com/stjude-rust-labs/crankshaft/actions/runs/14199541726/job/39782864789#step:4:287)
2. The documentation in the example files along the lines of `cargo run --release --example <example>` results in `error: no example target named <example>`. Using `--bin` instead of `--example` works just fine, however.

After the change, I was able to run the docker example by using the original command in the documentation - but I don't have the other backends handy.

[Relevant Cargo book documentation](https://doc.rust-lang.org/cargo/reference/cargo-targets.html?highlight=example#examples) - if it's useful. This page seems to have all the target types.

---

Before submitting this PR, please make sure:

- [X] You have added a few sentences describing the PR here.
- [ ] You have added yourself or the appropriate individual as the assignee.
- [ ] You have added at least one relevant code reviewer to the PR.
- [X] Your code builds clean without any errors or warnings.
- [X] You have added tests (when appropriate).
- [X] You have updated the README or other documentation to account for these changes (when appropriate).
- [ ] You have added an entry to the relevant `CHANGELOG.md` (see ["keep a changelog"] for more information).
- [X] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
