### PR TITLE
fix: incorrect resources sizes used by the TES backend.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ rust-version = "1.83.0"
 
 [workspace.dependencies]
 anyhow = "1.0.98"
+approx = "0.5.1"
 async-trait = "0.1.88"
 base64 = "0.22"
 bollard = "0.19.0"

--- a/crankshaft-config/src/backend/defaults.rs
+++ b/crankshaft-config/src/backend/defaults.rs
@@ -24,7 +24,7 @@ pub struct Defaults {
     /// The amount of RAM (in GiB) to use during execution.
     ///
     /// This is a float because RAM can be allocated more granularly than in
-    /// gigabytes. These may be rounded to any level of precision that is
+    /// gibibytes. These may be rounded to any level of precision that is
     /// required for a particular environment.
     ram: Option<f64>,
 
@@ -37,7 +37,7 @@ pub struct Defaults {
     /// The amount of disk (in GiB) to use during execution.
     ///
     /// This is a float because disks can be allocated more granularly than in
-    /// gigabytes. These may be rounded to any level of precision that is
+    /// gibibytes. These may be rounded to any level of precision that is
     /// required for a particular environment.
     disk: Option<f64>,
 }

--- a/crankshaft-docker/CHANGELOG.md
+++ b/crankshaft-docker/CHANGELOG.md
@@ -22,7 +22,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 * Added support for respecting CPU and memory limits
   ([#16](https://github.com/stjude-rust-labs/crankshaft/pull/16)).
 * Added support for submitting tasks via the service API for Docker Swarm
-  (#[11](https://github.com/stjude-rust-labs/crankshaft/pull/11)).
+  ([#11](https://github.com/stjude-rust-labs/crankshaft/pull/11)).
 * Adds the initial version of the crate.
 
 ### Changed

--- a/crankshaft-engine/CHANGELOG.md
+++ b/crankshaft-engine/CHANGELOG.md
@@ -35,9 +35,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 * Added support for bind mounting inputs to the Docker backend
   ([#12](https://github.com/stjude-rust-labs/crankshaft/pull/12)).
 * Added cancellation support to the engine and ctrl-c handling in the examples
-  (#[11](https://github.com/stjude-rust-labs/crankshaft/pull/11)).
+  ([#11](https://github.com/stjude-rust-labs/crankshaft/pull/11)).
 * Added support for Docker Swarm in the docker backend
-  (#[11](https://github.com/stjude-rust-labs/crankshaft/pull/11)).
+  ([#11](https://github.com/stjude-rust-labs/crankshaft/pull/11)).
 * Adds the initial version of the crate.
 * Adds basic auth to the TES examples
   ([[#6](https://github.com/stjude-rust-labs/crankshaft/issues/6)]).

--- a/crankshaft-engine/CHANGELOG.md
+++ b/crankshaft-engine/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Fixed
+
+* Fixed improper unit conversion in the TES backend ([#37](https://github.com/stjude-rust-labs/crankshaft/pull/37)).
+
 ## 0.3.0 - 05-28-2025
 
 ### Changed

--- a/crankshaft-engine/Cargo.toml
+++ b/crankshaft-engine/Cargo.toml
@@ -36,5 +36,8 @@ url.workspace = true
 uuid.workspace = true
 whoami.workspace = true
 
+[dev-dependencies]
+approx.workspace = true
+
 [lints]
 workspace = true


### PR DESCRIPTION
The TES API defines both `ram_gb` and `disk_gb` as having gigabyte (GB) units while the Crankshaft resources are specified in gibibytes (GiB).

However, the conversion from a Crankshaft resources into a TES resources fails to convert between the units.

The fix is to convert from GiB to GB for these fields.

This also corrects rounding up `cpu` to its ceiling and removes the limitation of not specifying zones.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
