### PR TITLE
feat: implement bearer token auth for TES backend.

### DIFF
--- a/crankshaft-config/Cargo.toml
+++ b/crankshaft-config/Cargo.toml
@@ -10,6 +10,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+base64.workspace = true
 bon.workspace = true
 config.workspace = true
 dirs.workspace = true

--- a/crankshaft-config/src/backend/tes/http.rs
+++ b/crankshaft-config/src/backend/tes/http.rs
@@ -1,7 +1,40 @@
 //! Configuration related to HTTP within the TES execution backend.
 
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD;
 use serde::Deserialize;
 use serde::Serialize;
+
+/// Represents HTTP authentication configuration.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case", tag = "type")]
+pub enum HttpAuthConfig {
+    /// Use basic authentication.
+    Basic {
+        /// The username for the authentication.
+        username: String,
+        /// The password for the authentication.
+        password: String,
+    },
+    /// Use bearer token authentication.
+    Bearer {
+        /// The bearer token for authentication.
+        token: String,
+    },
+}
+
+impl HttpAuthConfig {
+    /// Gets the `Authorization` header value based on the config.
+    pub fn header_value(&self) -> String {
+        match self {
+            Self::Basic { username, password } => format!(
+                "Basic {encoded}",
+                encoded = STANDARD.encode(format!("{username}:{password}"))
+            ),
+            Self::Bearer { token } => format!("Bearer {token}"),
+        }
+    }
+}
 
 /// A configuration object for HTTP settings within the TES execution backend.
 // **NOTE:** all default values for this struct need to be tested below to
@@ -9,8 +42,8 @@ use serde::Serialize;
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct Config {
-    /// If needed, the basic auth token to provide to the service.
-    pub basic_auth_token: Option<String>,
+    /// The HTTP authentication to use.
+    pub auth: Option<HttpAuthConfig>,
 }
 
 #[cfg(test)]
@@ -20,6 +53,6 @@ mod tests {
     #[test]
     fn defaults() {
         let options = Config::default();
-        assert_eq!(options.basic_auth_token, None);
+        assert!(options.auth.is_none());
     }
 }

--- a/crankshaft-engine/src/service/runner/backend/tes.rs
+++ b/crankshaft-engine/src/service/runner/backend/tes.rs
@@ -66,8 +66,8 @@ impl Backend {
         let (url, config, interval) = config.into_parts();
         let mut builder = Client::builder().url(url);
 
-        if let Some(token) = config.basic_auth_token {
-            builder = builder.insert_header("Authorization", format!("Basic {}", token));
+        if let Some(auth) = &config.auth {
+            builder = builder.insert_header("Authorization", auth.header_value());
         }
 
         Self {

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -12,7 +12,6 @@ rust-version.workspace = true
 [dependencies]
 anyhow.workspace = true
 crankshaft = { path = "../crankshaft" }
-base64.workspace = true
 clap.workspace = true
 dirs.workspace = true
 nonempty.workspace = true

--- a/examples/src/tes/main.rs
+++ b/examples/src/tes/main.rs
@@ -16,8 +16,6 @@ use anyhow::Context;
 use anyhow::Result;
 use anyhow::anyhow;
 use anyhow::bail;
-use base64::Engine as _;
-use base64::engine::general_purpose::STANDARD;
 use clap::Parser;
 use crankshaft::Engine;
 use crankshaft::config::backend::Kind;
@@ -79,9 +77,7 @@ async fn run(args: Args, token: CancellationToken) -> Result<()> {
 
     // If username and password are available, add them to the config.
     if let (Some(username), Some(password)) = (username, password) {
-        let credentials = format!("{}:{}", username, password);
-        let token = STANDARD.encode(credentials);
-        http_config.basic_auth_token = Some(token);
+        http_config.auth = Some(http::HttpAuthConfig::Basic { username, password });
     }
 
     let config = crankshaft::config::backend::Config::builder()


### PR DESCRIPTION
This PR implements support for bearer token auth in the TES backend.

The TES backend configuration now takes the username and password for the basic auth rather than the base64 encoded value.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
- [ ] You have added an entry to the relevant `CHANGELOG.md` (see ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
