### PR TITLE
fix: expose `crankshaft-docker` via the `crankshaft` crate.

### DIFF
--- a/crankshaft/CHANGELOG.md
+++ b/crankshaft/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+* Added the `docker` module for re-exporting `crankshaft-docker` ([#52](https://github.com/stjude-rust-labs/crankshaft/pull/52)).
 * Added the `events` module for re-exporting `crankshaft-events` ([#50](https://github.com/stjude-rust-labs/crankshaft/pull/50)).
 
 ## 0.4.0 - 06-04-2025

--- a/crankshaft/Cargo.toml
+++ b/crankshaft/Cargo.toml
@@ -10,14 +10,16 @@ repository.workspace = true
 rust-version.workspace = true
 
 [features]
-default = ["config", "engine", "events"]
+default = ["config", "engine", "events", "docker"]
 config = ["dep:crankshaft-config"]
 engine = ["dep:crankshaft-engine"]
 events = ["dep:crankshaft-events"]
+docker = ["dep:crankshaft-docker"]
 monitoring = ["dep:crankshaft-engine", "crankshaft-engine/monitoring"]
 
 [dependencies]
 crankshaft-config = { path = "../crankshaft-config", version = "0.3.0", optional = true }
+crankshaft-docker = { path = "../crankshaft-docker", version = "0.2.0", optional = true }
 crankshaft-engine = { path = "../crankshaft-engine", version = "0.4.0", optional = true }
 crankshaft-events = { path = "../crankshaft-events", version = "0.1.0", optional = true }
 

--- a/crankshaft/Cargo.toml
+++ b/crankshaft/Cargo.toml
@@ -10,7 +10,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [features]
-default = ["config", "engine", "events", "docker"]
+default = ["config", "engine", "events"]
 config = ["dep:crankshaft-config"]
 engine = ["dep:crankshaft-engine"]
 events = ["dep:crankshaft-events"]

--- a/crankshaft/src/lib.rs
+++ b/crankshaft/src/lib.rs
@@ -6,6 +6,9 @@ pub use crankshaft_config as config;
 #[cfg(feature = "config")]
 #[doc(inline)]
 pub use crankshaft_config::Config;
+#[cfg(feature = "docker")]
+#[doc(inline)]
+pub use crankshaft_docker as docker;
 #[cfg(feature = "engine")]
 #[doc(inline)]
 pub use crankshaft_engine as engine;
@@ -15,6 +18,3 @@ pub use crankshaft_engine::Engine;
 #[cfg(feature = "events")]
 #[doc(inline)]
 pub use crankshaft_events as events;
-#[cfg(feature = "docker")]
-#[doc(inline)]
-pub use crankshaft_docker as docker;

--- a/crankshaft/src/lib.rs
+++ b/crankshaft/src/lib.rs
@@ -15,3 +15,6 @@ pub use crankshaft_engine::Engine;
 #[cfg(feature = "events")]
 #[doc(inline)]
 pub use crankshaft_events as events;
+#[cfg(feature = "docker")]
+#[doc(inline)]
+pub use crankshaft_docker as docker;


### PR DESCRIPTION
This PR adds a `docker` feature to re-export the `crankshaft-docker` crate as a `docker` module of `crankshaft`.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
