### PR TITLE
fix: add user's effective gid for Docker containers.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ futures-util = "0.3.31"
 growable-bloom-filter = "2.1.1"
 indexmap = { version = "2.11.0", features = ["serde"] }
 indicatif = "0.18.0"
-libc = "0.2.175"
+nix = { version = "0.30.1", default-features = false, features = ["user"] }
 nonempty = "0.12.0"
 prost = "0.14.1"
 prost-types = "0.14.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ futures-util = "0.3.31"
 growable-bloom-filter = "2.1.1"
 indexmap = { version = "2.11.0", features = ["serde"] }
 indicatif = "0.18.0"
+libc = "0.2.175"
 nonempty = "0.12.0"
 prost = "0.14.1"
 prost-types = "0.14.1"

--- a/crankshaft-docker/CHANGELOG.md
+++ b/crankshaft-docker/CHANGELOG.md
@@ -10,6 +10,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+* Added the caller's effective gid to containers so a container's user can
+  access mounts and working directory ([#54](https://github.com/stjude-rust-labs/crankshaft/pull/54)).
 * Implemented sending events through the broadcast channel ([#44](https://github.com/stjude-rust-labs/crankshaft/pull/44)).
 
 ### Changed

--- a/crankshaft-docker/Cargo.toml
+++ b/crankshaft-docker/Cargo.toml
@@ -33,6 +33,7 @@ clap-verbosity-flag = { workspace = true, optional = true }
 crankshaft-events = { path = "../crankshaft-events", version = "0.1.0" }
 futures.workspace = true
 indexmap = { workspace = true }
+libc.workspace = true
 serde.workspace = true
 shlex = { workspace = true, optional = true }
 tar.workspace = true

--- a/crankshaft-docker/Cargo.toml
+++ b/crankshaft-docker/Cargo.toml
@@ -33,7 +33,7 @@ clap-verbosity-flag = { workspace = true, optional = true }
 crankshaft-events = { path = "../crankshaft-events", version = "0.1.0" }
 futures.workspace = true
 indexmap = { workspace = true }
-libc.workspace = true
+nix.workspace = true
 serde.workspace = true
 shlex = { workspace = true, optional = true }
 tar.workspace = true
@@ -45,6 +45,7 @@ tracing-log = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true, optional = true }
 
 [dev-dependencies]
+tempfile.workspace = true
 
 [lints]
 workspace = true

--- a/crankshaft-docker/src/bin/docker-driver.rs
+++ b/crankshaft-docker/src/bin/docker-driver.rs
@@ -97,6 +97,7 @@ async fn create_container(
 ) -> Result<Container> {
     Ok(docker
         .container_builder()
+        .name(name)
         .image(format!(
             "{image}:{tag}",
             image = image.as_ref(),
@@ -104,7 +105,7 @@ async fn create_container(
         ))
         .program(program)
         .args(args)
-        .try_build(name)
+        .try_build()
         .await?)
 }
 

--- a/crankshaft-docker/src/service/builder.rs
+++ b/crankshaft-docker/src/service/builder.rs
@@ -173,6 +173,10 @@ impl Builder {
                             dir: self.work_dir,
                             env: Some(self.env.iter().map(|(k, v)| format!("{k}={v}")).collect()),
                             mounts: Some(self.mounts),
+                            // Ensure the caller's group id is added so that the container can
+                            // access the mounts and working directory
+                            #[cfg(unix)]
+                            groups: Some(vec![unsafe { libc::getegid() }.to_string()]),
                             ..Default::default()
                         }),
                         resources: self.resources,

--- a/crankshaft-docker/src/service/builder.rs
+++ b/crankshaft-docker/src/service/builder.rs
@@ -25,6 +25,9 @@ pub struct Builder {
     /// container.
     client: Docker,
 
+    /// The name of the service.
+    name: Option<String>,
+
     /// The image (e.g., `ubuntu:latest`).
     image: Option<String>,
 
@@ -58,6 +61,7 @@ impl Builder {
     pub fn new(client: Docker) -> Self {
         Self {
             client,
+            name: None,
             image: Default::default(),
             program: Default::default(),
             args: Default::default(),
@@ -68,6 +72,12 @@ impl Builder {
             mounts: Default::default(),
             resources: Default::default(),
         }
+    }
+
+    /// Sets the name of the service.
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.name = Some(name.into());
+        self
     }
 
     /// Adds an image name.
@@ -147,7 +157,7 @@ impl Builder {
     }
 
     /// Consumes `self` and attempts to create a Docker service.
-    pub async fn try_build(self, name: impl Into<String>) -> Result<Service> {
+    pub async fn try_build(self) -> Result<Service> {
         let image = self
             .image
             .ok_or_else(|| Error::MissingBuilderField("image"))?;
@@ -155,12 +165,11 @@ impl Builder {
             .program
             .ok_or_else(|| Error::MissingBuilderField("program"))?;
 
-        let name = name.into();
         let response = self
             .client
             .create_service(
                 ServiceSpec {
-                    name: Some(name.clone()),
+                    name: self.name,
                     mode: Some(ServiceSpecMode {
                         replicated: Some(ServiceSpecModeReplicated { replicas: Some(1) }),
                         ..Default::default()
@@ -176,7 +185,7 @@ impl Builder {
                             // Ensure the caller's group id is added so that the container can
                             // access the mounts and working directory
                             #[cfg(unix)]
-                            groups: Some(vec![unsafe { libc::getegid() }.to_string()]),
+                            groups: Some(vec![nix::unistd::Gid::effective().to_string()]),
                             ..Default::default()
                         }),
                         resources: self.resources,
@@ -199,7 +208,9 @@ impl Builder {
 
         Ok(Service {
             client: self.client,
-            name,
+            id: response.id.ok_or_else(|| {
+                Error::Message("Docker daemon response did not contain a service identifier".into())
+            })?,
             stdout: self.stdout,
             stderr: self.stderr,
         })

--- a/crankshaft-engine/CHANGELOG.md
+++ b/crankshaft-engine/CHANGELOG.md
@@ -10,6 +10,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+* Docker backend: added the caller's effective gid to containers so a
+  container's user can access mounts and working directory ([#54](https://github.com/stjude-rust-labs/crankshaft/pull/54)).
 * Added `monitoring` compile-time feature for enabling support for monitoring
   in `Engine` ([#49](https://github.com/stjude-rust-labs/crankshaft/pull/49)).
 * Implemented starting a monitor server via the `Engine`; backends now send

--- a/crankshaft-engine/Cargo.toml
+++ b/crankshaft-engine/Cargo.toml
@@ -25,7 +25,7 @@ crankshaft-monitor = { path = "../crankshaft-monitor", version = "0.1.0", option
 futures.workspace = true
 growable-bloom-filter.workspace = true
 indexmap.workspace = true
-libc.workspace = true
+nix.workspace = true
 nonempty.workspace = true
 rand.workspace = true
 regex.workspace = true

--- a/crankshaft-engine/Cargo.toml
+++ b/crankshaft-engine/Cargo.toml
@@ -25,6 +25,7 @@ crankshaft-monitor = { path = "../crankshaft-monitor", version = "0.1.0", option
 futures.workspace = true
 growable-bloom-filter.workspace = true
 indexmap.workspace = true
+libc.workspace = true
 nonempty.workspace = true
 rand.workspace = true
 regex.workspace = true

--- a/crankshaft-engine/src/service/runner/backend/docker.rs
+++ b/crankshaft-engine/src/service/runner/backend/docker.rs
@@ -499,6 +499,9 @@ impl crate::Backend for Backend {
                             .envs(execution.env)
                             .host_config(HostConfig {
                                 mounts: Some(mounts.clone()),
+                                // Ensure the caller's group id is added so that the container can access the mounts and working directory
+                                #[cfg(unix)]
+                                group_add: Some(vec![unsafe{ libc::getegid() }.to_string()]),
                                 ..task.resources.as_ref().map(|r| r.into()).unwrap_or_default()
                             });
 


### PR DESCRIPTION
This PR adds the user's effective gid for containers started by the Docker backend.

The intention is to allow containers using an image with a `USER` directive to access the working directory and other mount points under the assumption that the calling user's group also has access.

This is similar to what `miniwdl` does to allow containers running as a specific uid to access mounts.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
