### PR TITLE
fix: fix missing log outputs for Docker backend when in Swarm.

### DIFF
--- a/crankshaft-docker/CHANGELOG.md
+++ b/crankshaft-docker/CHANGELOG.md
@@ -16,6 +16,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 * Based events on `crankshaft-events` ([#49](https://github.com/stjude-rust-labs/crankshaft/pull/49)).
 
+### Fixed
+
+* Fixed Docker backend to write logs when interacting with a swarm ([#55](https://github.com/stjude-rust-labs/crankshaft/pull/55)).
+
 ## 0.2.0 - 04-01-2025
 
 ### Changed


### PR DESCRIPTION
When the local Docker daemon is participating in a swarm, log files were only being written if the task state becomes "starting" or "running".

However, it is possible for the container to be short lived enough that the container goes directly from a pending to a "completed" state; when this happens we skipped writing the logs.

The fix was to refactor the log writing to share between the container (non-swarm) and service (swarm) implementations and to call `write_logs` from seeing a "completed" state.

Cleaned up the service implementation a bit as well, returning errors if the Docker daemon gives unexpected responses instead of panicking

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
