### PR TITLE
feat: adds cancellation support to `ensure_image`

### DIFF
--- a/crankshaft-docker/CHANGELOG.md
+++ b/crankshaft-docker/CHANGELOG.md
@@ -8,6 +8,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Changed
+
+* `ensure_image` now accepts a `CancellationToken` and returns
+  `Result<Option<()>>`, allowing image pulls to be cancelled mid-stream
+  ([#77](https://github.com/stjude-rust-labs/crankshaft/pull/77)).
+
 ## 0.4.0 - 01-12-2026
 
 ### Revised

--- a/crankshaft-docker/Cargo.toml
+++ b/crankshaft-docker/Cargo.toml
@@ -37,6 +37,7 @@ shlex = { workspace = true, optional = true }
 thiserror = { workspace = true }
 tokio.workspace = true
 tokio-retry2.workspace = true
+tokio-util.workspace = true
 tokio-stream.workspace = true
 tracing.workspace = true
 tracing-log = { workspace = true, optional = true }

--- a/crankshaft-docker/src/bin/docker-driver.rs
+++ b/crankshaft-docker/src/bin/docker-driver.rs
@@ -11,6 +11,7 @@ use clap::Subcommand;
 use clap_verbosity_flag::Verbosity;
 use crankshaft_docker::Container;
 use crankshaft_docker::Docker;
+use tokio_util::sync::CancellationToken;
 use tracing_log::AsTrace;
 use tracing_subscriber::EnvFilter;
 
@@ -150,7 +151,10 @@ async fn run(args: Args) -> Result<()> {
             }
         }
         Command::EnsureImage { image } => {
-            docker.ensure_image(image).await?;
+            docker
+                .ensure_image(image, CancellationToken::new())
+                .await?
+                .expect("pull should not be cancelled");
         }
         Command::ListImages => {
             docker.list_images().await?;

--- a/crankshaft-docker/src/images.rs
+++ b/crankshaft-docker/src/images.rs
@@ -127,37 +127,35 @@ pub(crate) async fn ensure_image(
 
                 let update = result.map_err(Error::Docker)?;
 
-                if enabled!(Level::TRACE) {
-                    trace!(
-                        "pull update: {}",
-                        [
-                            update.id.map(|id| format!("id: {id}")),
-                            update.error.map(|err| format!("error: {err}")),
-                            update.status.map(|status| format!("status: {status}")),
-                            update.progress.map(|progress| format!(
-                                "progress: {progress}{}",
-                                update
-                                    .progress_detail
-                                    .map(|detailed| format!(
-                                        " ({}/{})",
-                                        detailed
-                                            .current
-                                            .map(|v| v.to_string())
-                                            .unwrap_or(String::from("?")),
-                                        detailed
-                                            .total
-                                            .map(|v| v.to_string())
-                                            .unwrap_or(String::from("?"))
-                                    ))
-                                    .unwrap_or_default()
-                            ))
-                        ]
-                        .into_iter()
-                        .flatten()
-                        .collect::<Vec<_>>()
-                        .join("; ")
-                    )
-                }
+                trace!(
+                    "pull update: {}",
+                    [
+                        update.id.map(|id| format!("id: {id}")),
+                        update.error.map(|err| format!("error: {err}")),
+                        update.status.map(|status| format!("status: {status}")),
+                        update.progress.map(|progress| format!(
+                            "progress: {progress}{}",
+                            update
+                                .progress_detail
+                                .map(|detailed| format!(
+                                    " ({}/{})",
+                                    detailed
+                                        .current
+                                        .map(|v| v.to_string())
+                                        .unwrap_or(String::from("?")),
+                                    detailed
+                                        .total
+                                        .map(|v| v.to_string())
+                                        .unwrap_or(String::from("?"))
+                                ))
+                                .unwrap_or_default()
+                        ))
+                    ]
+                    .into_iter()
+                    .flatten()
+                    .collect::<Vec<_>>()
+                    .join("; ")
+                )
             }
         }
     }

--- a/crankshaft-docker/src/images.rs
+++ b/crankshaft-docker/src/images.rs
@@ -14,6 +14,8 @@ use tracing::debug;
 use tracing::enabled;
 use tracing::trace;
 
+use tokio_util::sync::CancellationToken;
+
 use crate::Docker;
 use crate::Error;
 use crate::Result;
@@ -63,7 +65,11 @@ pub(crate) async fn list_images(docker: &Docker) -> Result<Vec<ImageSummary>> {
 ///
 /// * Confirming that the image already exists there, or
 /// * Pulling the image from the remote repository.
-pub(crate) async fn ensure_image(docker: &Docker, image: impl Into<String>) -> Result<()> {
+pub(crate) async fn ensure_image(
+    docker: &Docker,
+    image: impl Into<String>,
+    token: CancellationToken,
+) -> Result<Option<()>> {
     let image = image.into();
 
     debug!("ensuring image `{image}` exists locally");
@@ -89,7 +95,7 @@ pub(crate) async fn ensure_image(docker: &Docker, image: impl Into<String>) -> R
             );
         }
 
-        return Ok(());
+        return Ok(Some(()));
     }
 
     debug!("image `{image}` does not exist locally; attempting to pull from remote");
@@ -107,43 +113,57 @@ pub(crate) async fn ensure_image(docker: &Docker, image: impl Into<String>) -> R
         None,
     );
 
-    while let Some(result) = stream.next().await {
-        let update = result.map_err(Error::Docker)?;
+    loop {
+        tokio::select! {
+            biased;
 
-        if enabled!(Level::TRACE) {
-            trace!(
-                "pull update: {}",
-                [
-                    update.id.map(|id| format!("id: {id}")),
-                    update.error.map(|err| format!("error: {err}")),
-                    update.status.map(|status| format!("status: {status}")),
-                    update.progress.map(|progress| format!(
-                        "progress: {progress}{}",
-                        update
-                            .progress_detail
-                            .map(|detailed| format!(
-                                " ({}/{})",
-                                detailed
-                                    .current
-                                    .map(|v| v.to_string())
-                                    .unwrap_or(String::from("?")),
-                                detailed
-                                    .total
-                                    .map(|v| v.to_string())
-                                    .unwrap_or(String::from("?"))
+            _ = token.cancelled() => {
+                debug!("image pull cancelled");
+                return Ok(None);
+            }
+            item = stream.next() => {
+                let Some(result) = item else {
+                    break;
+                };
+
+                let update = result.map_err(Error::Docker)?;
+
+                if enabled!(Level::TRACE) {
+                    trace!(
+                        "pull update: {}",
+                        [
+                            update.id.map(|id| format!("id: {id}")),
+                            update.error.map(|err| format!("error: {err}")),
+                            update.status.map(|status| format!("status: {status}")),
+                            update.progress.map(|progress| format!(
+                                "progress: {progress}{}",
+                                update
+                                    .progress_detail
+                                    .map(|detailed| format!(
+                                        " ({}/{})",
+                                        detailed
+                                            .current
+                                            .map(|v| v.to_string())
+                                            .unwrap_or(String::from("?")),
+                                        detailed
+                                            .total
+                                            .map(|v| v.to_string())
+                                            .unwrap_or(String::from("?"))
+                                    ))
+                                    .unwrap_or_default()
                             ))
-                            .unwrap_or_default()
-                    ))
-                ]
-                .into_iter()
-                .flatten()
-                .collect::<Vec<_>>()
-                .join("; ")
-            )
+                        ]
+                        .into_iter()
+                        .flatten()
+                        .collect::<Vec<_>>()
+                        .join("; ")
+                    )
+                }
+            }
         }
     }
 
-    Ok(())
+    Ok(Some(()))
 }
 
 /// Removes an image from the Docker daemon.

--- a/crankshaft-docker/src/images.rs
+++ b/crankshaft-docker/src/images.rs
@@ -9,12 +9,11 @@ use bollard::secret::ImageDeleteResponseItem;
 use bollard::secret::ImageSummary;
 use futures::stream::FuturesUnordered;
 use tokio_stream::StreamExt as _;
+use tokio_util::sync::CancellationToken;
 use tracing::Level;
 use tracing::debug;
 use tracing::enabled;
 use tracing::trace;
-
-use tokio_util::sync::CancellationToken;
 
 use crate::Docker;
 use crate::Error;

--- a/crankshaft-docker/src/lib.rs
+++ b/crankshaft-docker/src/lib.rs
@@ -87,7 +87,6 @@ impl Docker {
     ///
     /// * Confirming that the image already exists there, or
     /// * Pulling the image from the remote repository.
-    /// Ensures that an image exists in the Docker daemon.
     ///
     /// Returns `Ok(None)` if the pull was cancelled via the provided token.
     pub async fn ensure_image(

--- a/crankshaft-docker/src/lib.rs
+++ b/crankshaft-docker/src/lib.rs
@@ -87,8 +87,15 @@ impl Docker {
     ///
     /// * Confirming that the image already exists there, or
     /// * Pulling the image from the remote repository.
-    pub async fn ensure_image(&self, image: impl Into<String>) -> Result<()> {
-        ensure_image(self, image).await
+    /// Ensures that an image exists in the Docker daemon.
+    ///
+    /// Returns `Ok(None)` if the pull was cancelled via the provided token.
+    pub async fn ensure_image(
+        &self,
+        image: impl Into<String>,
+        token: tokio_util::sync::CancellationToken,
+    ) -> Result<Option<()>> {
+        ensure_image(self, image, token).await
     }
 
     /// Removes an image from the Docker daemon.

--- a/crankshaft-engine/src/service/runner/backend/docker.rs
+++ b/crankshaft-engine/src/service/runner/backend/docker.rs
@@ -405,10 +405,14 @@ impl crate::Backend for Backend {
                     }
 
                     // First ensure the execution's image exists
-                    client
-                        .ensure_image(&execution.image)
+                    match client
+                        .ensure_image(&execution.image, token.clone())
                         .await
-                        .with_context(|| format!("failed to pull image `{image}`", image = execution.image))?;
+                        .with_context(|| format!("failed to pull image `{image}`", image = execution.image))?
+                    {
+                        Some(()) => {}
+                        None => return Err(TaskRunError::Canceled),
+                    }
 
                     // Look for the path where the caller wants stdout saved to
                     let stdout = execution.stdout.as_ref().and_then(|p| {


### PR DESCRIPTION
`ensure_image` previously had no way to be cancelled mid-pull. Since Docker image pulls can take a while (especially for large images or slow registries), this left a gap where a cancelled task would block until the pull finished.

This threads a `CancellationToken` through `ensure_image` and uses a biased `tokio::select!` in the pull stream loop so cancellation takes effect between progress chunks rather than waiting for the entire pull to complete. The return type changes from `Result<()>` to `Result<Option<()>>`—`None` meaning the pull was cancelled.

The engine's Docker backend already had a cancellation token available; it now passes it through and maps `None` to `TaskRunError::Canceled`.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/