### PR TITLE
feat: image pull events

### DIFF
--- a/crankshaft-config/src/backend/docker.rs
+++ b/crankshaft-config/src/backend/docker.rs
@@ -12,6 +12,25 @@ fn default_cleanup() -> bool {
     DEFAULT_CLEANUP
 }
 
+/// Configuration for events emitted by the Docker execution backend.
+#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct EventConfig {
+    /// Whether or not to send the task stdout event.
+    pub send_stdout: bool,
+    /// Whether or not to send the task stderr event.
+    pub send_stderr: bool,
+}
+
+impl Default for EventConfig {
+    fn default() -> Self {
+        Self {
+            send_stdout: true,
+            send_stderr: true,
+        }
+    }
+}
+
 /// A configuration object for a Docker execution backend.
 #[derive(Builder, Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
@@ -22,6 +41,10 @@ pub struct Config {
     #[serde(default = "default_cleanup")]
     #[builder(default = DEFAULT_CLEANUP)]
     cleanup: bool,
+    /// Configuration for events emitted by the Docker execution backend.
+    #[serde(default)]
+    #[builder(default)]
+    events: EventConfig,
 }
 
 impl Config {
@@ -30,6 +53,11 @@ impl Config {
     /// failure).
     pub fn cleanup(&self) -> bool {
         self.cleanup
+    }
+
+    /// Gets the event configuration for the backend.
+    pub fn events(&self) -> EventConfig {
+        self.events
     }
 }
 

--- a/crankshaft-console/src/state/task.rs
+++ b/crankshaft-console/src/state/task.rs
@@ -3,6 +3,9 @@ use std::collections::BTreeMap;
 use std::collections::HashMap;
 
 use crankshaft_monitor::proto::Event;
+use crankshaft_monitor::proto::ImagePullFailedEvent;
+use crankshaft_monitor::proto::ImagePullFinishedEvent;
+use crankshaft_monitor::proto::ImagePullStartedEvent;
 use crankshaft_monitor::proto::TaskCanceledEvent;
 use crankshaft_monitor::proto::TaskCompletedEvent;
 use crankshaft_monitor::proto::TaskContainerCreatedEvent;
@@ -31,7 +34,10 @@ impl TuiTasksState {
     /// Updates the state with a new event.
     pub fn update(&mut self, event: Event) {
         let id = match &event.event_kind {
-            Some(EventKind::Created(TaskCreatedEvent { id, .. }))
+            Some(EventKind::ImagePullStarted(ImagePullStartedEvent { id, .. }))
+            | Some(EventKind::ImagePullFailed(ImagePullFailedEvent { id, .. }))
+            | Some(EventKind::ImagePullFinished(ImagePullFinishedEvent { id, .. }))
+            | Some(EventKind::Created(TaskCreatedEvent { id, .. }))
             | Some(EventKind::Started(TaskStartedEvent { id, .. }))
             | Some(EventKind::ContainerCreated(TaskContainerCreatedEvent { id, .. }))
             | Some(EventKind::ContainerExited(TaskContainerExitedEvent { id, .. }))
@@ -185,6 +191,9 @@ impl Task {
     /// Gets the display status of the task.
     pub fn status(&self) -> &str {
         match &self.last_event().event_kind {
+            Some(EventKind::ImagePullStarted(_) | EventKind::ImagePullFinished(_)) => {
+                "Pulling image"
+            }
             Some(EventKind::Created(_)) => "Created",
             Some(EventKind::Started(_))
             | Some(EventKind::ContainerCreated(_))
@@ -192,7 +201,7 @@ impl Task {
             | Some(EventKind::Stdout(_))
             | Some(EventKind::Stderr(_)) => "Running",
             Some(EventKind::Completed(_)) => "Completed",
-            Some(EventKind::Failed(_)) => "Failed",
+            Some(EventKind::Failed(_) | EventKind::ImagePullFailed(_)) => "Failed",
             Some(EventKind::Canceled(_)) => "Canceled",
             Some(EventKind::Preempted(_)) => "Preempted",
             None => "Unknown",
@@ -209,6 +218,15 @@ impl Task {
     /// Gets the message representation of the task's most recent event.
     pub fn message(&self) -> String {
         match &self.last_event().event_kind {
+            Some(EventKind::ImagePullStarted(ImagePullStartedEvent { name, .. })) => {
+                format!("pulling image `{name}`")
+            }
+            Some(EventKind::ImagePullFailed(ImagePullFailedEvent { name, message, .. })) => {
+                format!("image pull for `{name}` failed: {message}")
+            }
+            Some(EventKind::ImagePullFinished(ImagePullFinishedEvent { name, .. })) => {
+                format!("finished pulling image `{name}`")
+            }
             Some(EventKind::Created(_)) => {
                 format!("task `{name}` has been created", name = self.name)
             }

--- a/crankshaft-docker/CHANGELOG.md
+++ b/crankshaft-docker/CHANGELOG.md
@@ -10,7 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-* Added support for the `ImagePull{Started,Failed,Finished}` events ([#](https://github.com/stjude-rust-labs/crankshaft/pull/)).
+* Added support for the `ImagePull{Started,Failed,Finished}` events ([#82](https://github.com/stjude-rust-labs/crankshaft/pull/82)).
 
 ## 0.5.0 - 04-22-2026
 

--- a/crankshaft-docker/CHANGELOG.md
+++ b/crankshaft-docker/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+* Added support for the `ImagePull{Started,Failed,Finished}` events ([#](https://github.com/stjude-rust-labs/crankshaft/pull/)).
+
 ## 0.5.0 - 04-22-2026
 
 ### Changed

--- a/crankshaft-docker/Cargo.toml
+++ b/crankshaft-docker/Cargo.toml
@@ -29,6 +29,7 @@ anyhow.workspace = true
 bollard.workspace = true
 clap = { workspace = true, optional = true }
 clap-verbosity-flag = { workspace = true, optional = true }
+crankshaft-config = { path = "../crankshaft-config", version = "0.6.0" }
 crankshaft-events = { path = "../crankshaft-events", version = "0.1.0" }
 futures.workspace = true
 indexmap = { workspace = true }

--- a/crankshaft-docker/src/bin/docker-driver.rs
+++ b/crankshaft-docker/src/bin/docker-driver.rs
@@ -152,7 +152,7 @@ async fn run(args: Args) -> Result<()> {
         }
         Command::EnsureImage { image } => {
             docker
-                .ensure_image(image, CancellationToken::new())
+                .ensure_image(image, CancellationToken::new(), None)
                 .await?
                 .expect("pull should not be cancelled");
         }

--- a/crankshaft-docker/src/container.rs
+++ b/crankshaft-docker/src/container.rs
@@ -108,7 +108,9 @@ pub(crate) async fn write_logs(
                     })?;
                 }
 
-                if let Some(events) = events {
+                if let Some(events) = events
+                    && events.user_config.send_stdout
+                {
                     events
                         .sender
                         .send(Event::TaskStdout {
@@ -128,7 +130,9 @@ pub(crate) async fn write_logs(
                     })?;
                 }
 
-                if let Some(events) = &events {
+                if let Some(events) = &events
+                    && events.user_config.send_stderr
+                {
                     events
                         .sender
                         .send(Event::TaskStderr {
@@ -226,13 +230,17 @@ impl Container {
         }
 
         // Write the log streams
-        if self.stdout.is_some() || self.stderr.is_some() {
+        let stdout_enabled =
+            self.stdout.is_some() || events.as_ref().is_some_and(|e| e.user_config.send_stdout);
+        let stderr_enabled =
+            self.stderr.is_some() || events.as_ref().is_some_and(|e| e.user_config.send_stderr);
+        if stdout_enabled || stderr_enabled {
             let logs = self.client.logs(
                 &self.name,
                 Some(
                     LogsOptionsBuilder::new()
-                        .stdout(self.stdout.is_some())
-                        .stderr(self.stderr.is_some())
+                        .stdout(stdout_enabled)
+                        .stderr(stderr_enabled)
                         .follow(true)
                         .build(),
                 ),

--- a/crankshaft-docker/src/container/builder.rs
+++ b/crankshaft-docker/src/container/builder.rs
@@ -34,8 +34,14 @@ pub struct Builder {
     /// The file path to write the container's stdout stream to.
     stdout: Option<PathBuf>,
 
+    /// Whether to attach the container's stdout stream.
+    attach_stdout: bool,
+
     /// The file path to write the container's stderr stream to.
     stderr: Option<PathBuf>,
+
+    /// Whether to attach the container's stderr stream.
+    attach_stderr: bool,
 
     /// Environment variables.
     env: IndexMap<String, String>,
@@ -58,6 +64,8 @@ impl Builder {
             args: Default::default(),
             stdout: None,
             stderr: None,
+            attach_stdout: false,
+            attach_stderr: false,
             env: Default::default(),
             work_dir: Default::default(),
             host_config: Default::default(),
@@ -100,9 +108,25 @@ impl Builder {
         self
     }
 
+    /// Sets whether to attach the container's stdout stream.
+    ///
+    /// NOTE: [`Self::stdout()`] implies this to be true.
+    pub fn attach_stdout(mut self, attach: bool) -> Self {
+        self.attach_stdout = attach;
+        self
+    }
+
     /// Sets the file to write the container's stderr stream to.
     pub fn stderr(mut self, path: impl Into<PathBuf>) -> Self {
         self.stderr = Some(path.into());
+        self
+    }
+
+    /// Sets whether to attach the container's stderr stream.
+    ///
+    /// NOTE: [`Self::stderr()`] implies this to be true.
+    pub fn attach_stderr(mut self, attach: bool) -> Self {
+        self.attach_stderr = attach;
         self
     }
 
@@ -165,8 +189,8 @@ impl Builder {
                     // Override the entrypoint to the default Docker entrypoint as we're providing
                     // the full command
                     entrypoint: Some(vec![String::new()]),
-                    attach_stdout: Some(self.stdout.is_some()),
-                    attach_stderr: Some(self.stderr.is_some()),
+                    attach_stdout: Some(self.stdout.is_some() || self.attach_stdout),
+                    attach_stderr: Some(self.stderr.is_some() || self.attach_stderr),
                     // END NOTE
                     working_dir: self.work_dir,
                     host_config: self.host_config,

--- a/crankshaft-docker/src/images.rs
+++ b/crankshaft-docker/src/images.rs
@@ -8,6 +8,7 @@ use bollard::query_parameters::RemoveImageOptions;
 use bollard::secret::ImageDeleteResponseItem;
 use bollard::secret::ImageSummary;
 use crankshaft_events::Event;
+use crankshaft_events::TaskId;
 use crankshaft_events::send_event;
 use futures::stream::FuturesUnordered;
 use tokio::sync::broadcast;
@@ -71,7 +72,7 @@ pub(crate) async fn ensure_image(
     docker: &Docker,
     image: impl Into<String>,
     token: CancellationToken,
-    events_ctx: Option<(broadcast::Sender<Event>, u64)>,
+    events_ctx: Option<(broadcast::Sender<Event>, TaskId)>,
 ) -> Result<Option<()>> {
     let image = image.into();
 

--- a/crankshaft-docker/src/images.rs
+++ b/crankshaft-docker/src/images.rs
@@ -7,7 +7,10 @@ use bollard::query_parameters::ListImagesOptions;
 use bollard::query_parameters::RemoveImageOptions;
 use bollard::secret::ImageDeleteResponseItem;
 use bollard::secret::ImageSummary;
+use crankshaft_events::Event;
+use crankshaft_events::send_event;
 use futures::stream::FuturesUnordered;
+use tokio::sync::broadcast;
 use tokio_stream::StreamExt as _;
 use tokio_util::sync::CancellationToken;
 use tracing::Level;
@@ -68,6 +71,7 @@ pub(crate) async fn ensure_image(
     docker: &Docker,
     image: impl Into<String>,
     token: CancellationToken,
+    events_ctx: Option<(broadcast::Sender<Event>, u64)>,
 ) -> Result<Option<()>> {
     let image = image.into();
 
@@ -97,7 +101,18 @@ pub(crate) async fn ensure_image(
         return Ok(Some(()));
     }
 
+    let events = events_ctx.as_ref().map(|(sender, _)| sender.clone());
+    let task = events_ctx.as_ref().map(|(_, task_id)| *task_id);
+
     debug!("image `{image}` does not exist locally; attempting to pull from remote");
+    send_event!(
+        events,
+        Event::ImagePullStarted {
+            id: task.unwrap(),
+            name: image.clone()
+        }
+    );
+
     let mut stream = docker.inner().create_image(
         Some(CreateImageOptions {
             tag: Some(if image.contains(':') {
@@ -105,7 +120,7 @@ pub(crate) async fn ensure_image(
             } else {
                 String::from("latest")
             }),
-            from_image: Some(image),
+            from_image: Some(image.clone()),
             ..Default::default()
         }),
         None,
@@ -125,7 +140,20 @@ pub(crate) async fn ensure_image(
                     break;
                 };
 
-                let update = result.map_err(Error::Docker)?;
+                let update = match result {
+                    Ok(update) => update,
+                    Err(e) => {
+                        send_event!(
+                            events,
+                            Event::ImagePullFailed {
+                                id: task.unwrap(),
+                                name: image.clone(),
+                                message: e.to_string()
+                            }
+                        );
+                        return Err(Error::Docker(e));
+                    }
+                };
 
                 trace!(
                     "pull update: {}",
@@ -159,6 +187,14 @@ pub(crate) async fn ensure_image(
             }
         }
     }
+
+    send_event!(
+        events,
+        Event::ImagePullFinished {
+            id: task.unwrap(),
+            name: image
+        }
+    );
 
     Ok(Some(()))
 }

--- a/crankshaft-docker/src/lib.rs
+++ b/crankshaft-docker/src/lib.rs
@@ -12,6 +12,7 @@ pub mod service;
 
 use bollard::secret::Node;
 use bollard::secret::SystemInfo;
+use crankshaft_config::backend::docker::EventConfig;
 use crankshaft_events::Event;
 use crankshaft_events::TaskId;
 use thiserror::Error;
@@ -183,6 +184,8 @@ pub struct EventOptions {
     pub task_id: TaskId,
     /// Whether or not send the task started event.
     pub send_start: bool,
+    /// User-controlled event configuration.
+    pub user_config: EventConfig,
 }
 
 #[cfg(test)]

--- a/crankshaft-docker/src/lib.rs
+++ b/crankshaft-docker/src/lib.rs
@@ -13,6 +13,7 @@ pub mod service;
 use bollard::secret::Node;
 use bollard::secret::SystemInfo;
 use crankshaft_events::Event;
+use crankshaft_events::TaskId;
 use thiserror::Error;
 use tokio::sync::broadcast;
 
@@ -93,7 +94,7 @@ impl Docker {
         &self,
         image: impl Into<String>,
         token: tokio_util::sync::CancellationToken,
-        events_ctx: Option<(broadcast::Sender<Event>, u64)>,
+        events_ctx: Option<(broadcast::Sender<Event>, TaskId)>,
     ) -> Result<Option<()>> {
         ensure_image(self, image, token, events_ctx).await
     }
@@ -179,7 +180,7 @@ pub struct EventOptions {
     /// The sender for sending events.
     pub sender: broadcast::Sender<Event>,
     /// The task id for the events.
-    pub task_id: u64,
+    pub task_id: TaskId,
     /// Whether or not send the task started event.
     pub send_start: bool,
 }

--- a/crankshaft-docker/src/lib.rs
+++ b/crankshaft-docker/src/lib.rs
@@ -93,8 +93,9 @@ impl Docker {
         &self,
         image: impl Into<String>,
         token: tokio_util::sync::CancellationToken,
+        events_ctx: Option<(broadcast::Sender<Event>, u64)>,
     ) -> Result<Option<()>> {
-        ensure_image(self, image, token).await
+        ensure_image(self, image, token, events_ctx).await
     }
 
     /// Removes an image from the Docker daemon.

--- a/crankshaft-docker/src/service.rs
+++ b/crankshaft-docker/src/service.rs
@@ -200,13 +200,17 @@ impl Service {
                     }
 
                     // Write the logs
-                    if self.stdout.is_some() || self.stderr.is_some() {
+                    let stdout_enabled = self.stdout.is_some()
+                        || events.as_ref().is_some_and(|e| e.user_config.send_stdout);
+                    let stderr_enabled = self.stderr.is_some()
+                        || events.as_ref().is_some_and(|e| e.user_config.send_stderr);
+                    if stdout_enabled || stderr_enabled {
                         let logs = self.client.logs(
                             &container_id,
                             Some(
                                 LogsOptionsBuilder::new()
-                                    .stdout(true)
-                                    .stderr(true)
+                                    .stdout(stdout_enabled)
+                                    .stderr(stderr_enabled)
                                     .follow(true)
                                     .build(),
                             ),

--- a/crankshaft-engine/src/service/runner/backend/docker.rs
+++ b/crankshaft-engine/src/service/runner/backend/docker.rs
@@ -391,6 +391,7 @@ impl crate::Backend for Backend {
                 generator.next().unwrap()
             });
 
+            let events_ctx = events.clone().map(|e| (e, task_id));
             let run = async {
                 let tempdir = TempDir::new().context("failed to create temporary directory for mounts")?;
 
@@ -406,7 +407,7 @@ impl crate::Backend for Backend {
 
                     // First ensure the execution's image exists
                     match client
-                        .ensure_image(&execution.image, token.clone())
+                        .ensure_image(&execution.image, token.clone(), events_ctx.clone())
                         .await
                         .with_context(|| format!("failed to pull image `{image}`", image = execution.image))?
                     {

--- a/crankshaft-engine/src/service/runner/backend/docker.rs
+++ b/crankshaft-engine/src/service/runner/backend/docker.rs
@@ -331,6 +331,11 @@ impl Backend {
     pub fn resources(&self) -> &Resources {
         &self.resources
     }
+
+    /// Gets the events sender for the backend, if there is one.
+    pub fn events(&self) -> Option<broadcast::Sender<Event>> {
+        self.events.clone()
+    }
 }
 
 /// Helper for cleaning up a container or service.

--- a/crankshaft-engine/src/service/runner/backend/docker.rs
+++ b/crankshaft-engine/src/service/runner/backend/docker.rs
@@ -691,6 +691,65 @@ fn add_shared_mounts(volumes: Vec<String>, tempdir: &Path, mounts: &mut Vec<Moun
 
 #[cfg(test)]
 mod test {
+    use std::io::Write;
+    use std::ops::Deref;
+
+    use anyhow::Context;
+
+    use super::*;
+    use crate::service::runner::NAME_BUFFER_LEN;
+    use crate::task::output::Type;
+
+    struct BackendTest {
+        backend: Backend,
+    }
+
+    impl BackendTest {
+        async fn redirect_stdio(mut event_rx: broadcast::Receiver<Event>) -> anyhow::Result<()> {
+            while let Ok(event) = event_rx.recv().await {
+                match event {
+                    Event::TaskStdout { message, .. } => {
+                        std::io::stdout()
+                            .write_all(&*message)
+                            .context("failed to write stdout")?;
+                    }
+                    Event::TaskStderr { message, .. } => {
+                        std::io::stderr()
+                            .write_all(&*message)
+                            .context("failed to write stderr")?;
+                    }
+                    _ => {}
+                }
+            }
+
+            Ok(())
+        }
+
+        async fn new(config: Config) -> anyhow::Result<Self> {
+            let names = Arc::new(Mutex::new(GeneratorIterator::new(
+                UniqueAlphanumeric::default_with_expected_generations(NAME_BUFFER_LEN),
+                NAME_BUFFER_LEN,
+            )));
+
+            let (event_tx, event_rx) = broadcast::channel(1024);
+            tokio::task::spawn(Self::redirect_stdio(event_rx));
+
+            let backend = Backend::initialize_default_with(config, names, Some(event_tx))
+                .await
+                .context("failed to create backend")?;
+
+            Ok(Self { backend })
+        }
+    }
+
+    impl Deref for BackendTest {
+        type Target = Backend;
+
+        fn deref(&self) -> &Self::Target {
+            &self.backend
+        }
+    }
+
     #[tokio::test]
     #[cfg(target_os = "linux")]
     async fn backend_adds_user_egid() -> anyhow::Result<()> {
@@ -703,19 +762,10 @@ mod test {
 
         use super::*;
         use crate::service::runner::Backend as _;
-        use crate::service::runner::NAME_BUFFER_LEN;
         use crate::task::Execution;
         use crate::task::Output;
-        use crate::task::output::Type;
 
-        let names = Arc::new(Mutex::new(GeneratorIterator::new(
-            UniqueAlphanumeric::default_with_expected_generations(NAME_BUFFER_LEN),
-            NAME_BUFFER_LEN,
-        )));
-
-        let backend = Backend::initialize_default_with(Config::default(), names, None)
-            .await
-            .context("failed to create backend")?;
+        let backend = BackendTest::new(Config::default()).await?;
 
         // Get the current user's effective gid
         let gid = Gid::effective();

--- a/crankshaft-engine/src/service/runner/backend/docker.rs
+++ b/crankshaft-engine/src/service/runner/backend/docker.rs
@@ -790,10 +790,7 @@ mod test {
                         Execution::builder()
                             .image("ubuntu:latest")
                             .program("/bin/sh")
-                            .args([
-                                String::from("-c"),
-                                String::from("/usr/bin/id -G"),
-                            ])
+                            .args([String::from("-c"), String::from("/usr/bin/id -G")])
                             .stdout("/mnt/stdout")
                             .build(),
                     ))

--- a/crankshaft-engine/src/service/runner/backend/docker.rs
+++ b/crankshaft-engine/src/service/runner/backend/docker.rs
@@ -382,6 +382,7 @@ impl crate::Backend for Backend {
         let task_id = next_task_id();
         let client = self.client.clone();
         let run_cleanup = self.config.cleanup();
+        let events_config = self.config.events();
         let use_service = self.resources.use_service();
         let events = self.events.clone();
         let names = self.names.clone();
@@ -462,7 +463,9 @@ impl crate::Backend for Backend {
 
                     }).transpose()?;
 
-                    let options = events.clone().map(|sender| EventOptions { sender, task_id, send_start: i == 0});
+                    let options = events.clone().map(|sender| EventOptions { sender, task_id, send_start: i == 0, user_config: events_config });
+                    let attach_stdout = events.is_some() && events_config.send_stdout;
+                    let attach_stderr = events.is_some() && events_config.send_stderr;
 
                     // Generate a name for the service or container
                     let name = {
@@ -519,6 +522,8 @@ impl crate::Backend for Backend {
                             .program(execution.program)
                             .args(execution.args)
                             .envs(execution.env)
+                            .attach_stdout(attach_stdout)
+                            .attach_stderr(attach_stderr)
                             .host_config(HostConfig {
                                 mounts: Some(mounts.clone()),
                                 // Ensure the caller's group id is added so that the container can access the mounts and working directory
@@ -710,13 +715,16 @@ mod test {
                 match event {
                     Event::TaskStdout { message, .. } => {
                         std::io::stdout()
-                            .write_all(&*message)
+                            .write_all(&message)
                             .context("failed to write stdout")?;
                     }
                     Event::TaskStderr { message, .. } => {
                         std::io::stderr()
-                            .write_all(&*message)
+                            .write_all(&message)
                             .context("failed to write stderr")?;
+                    }
+                    Event::TaskFailed { message, .. } => {
+                        eprintln!("{message}");
                     }
                     _ => {}
                 }
@@ -781,7 +789,8 @@ mod test {
                     .executions(NonEmpty::new(
                         Execution::builder()
                             .image("ubuntu:latest")
-                            .program("/usr/bin/id")
+                            .program("/bin/sh")
+                            .args([String::from("-c"), String::from("/usr/bin/id")])
                             .stdout("/mnt/stdout")
                             .build(),
                     ))

--- a/crankshaft-engine/src/service/runner/backend/docker.rs
+++ b/crankshaft-engine/src/service/runner/backend/docker.rs
@@ -790,7 +790,10 @@ mod test {
                         Execution::builder()
                             .image("ubuntu:latest")
                             .program("/bin/sh")
-                            .args([String::from("-c"), String::from("/usr/bin/id")])
+                            .args([
+                                String::from("-c"),
+                                String::from("/usr/bin/id -G"),
+                            ])
                             .stdout("/mnt/stdout")
                             .build(),
                     ))
@@ -816,7 +819,7 @@ mod test {
         // Assert that the command output had the user's group added
         let stdout = fs::read_to_string(&stdout_path).context("failed to read stdout file")?;
         assert!(
-            stdout.contains(&format!("uid=0(root) gid=0(root) groups=0(root),{gid}")),
+            stdout.contains(&gid.to_string()),
             "task stdout of `{stdout}` did not contain the expected output"
         );
         Ok(())

--- a/crankshaft-engine/src/service/runner/backend/tes.rs
+++ b/crankshaft-engine/src/service/runner/backend/tes.rs
@@ -19,6 +19,7 @@ use anyhow::anyhow;
 use async_trait::async_trait;
 use crankshaft_config::backend::tes::Config;
 use crankshaft_events::Event;
+use crankshaft_events::TaskId;
 use crankshaft_events::next_task_id;
 use crankshaft_events::send_event;
 use futures::FutureExt as _;
@@ -159,7 +160,7 @@ impl Backend {
     async fn wait_task(
         state: &BackendState,
         monitor: &TaskMonitor,
-        task_id: u64,
+        task_id: TaskId,
         task_name: &str,
         tes_id: &str,
         completed: oneshot::Receiver<Result<()>>,

--- a/crankshaft-engine/src/service/runner/backend/tes/monitor.rs
+++ b/crankshaft-engine/src/service/runner/backend/tes/monitor.rs
@@ -10,6 +10,7 @@ use anyhow::Context;
 use anyhow::Result;
 use anyhow::anyhow;
 use crankshaft_events::Event;
+use crankshaft_events::TaskId;
 use crankshaft_events::send_event;
 use tes::v1::types::requests::ListTasksParams;
 use tes::v1::types::requests::MAX_PAGE_SIZE;
@@ -40,11 +41,11 @@ struct TaskMonitorState {
     /// The current tag to group TES tasks with.
     tag: String,
     /// The map of Crankshaft id to monitored task.
-    tasks: HashMap<u64, Task>,
+    tasks: HashMap<TaskId, Task>,
     /// The map of TES task id to Crankshaft task id
-    ids: HashMap<String, u64>,
+    ids: HashMap<String, TaskId>,
     /// Set of known running tasks
-    running: HashSet<u64>,
+    running: HashSet<TaskId>,
 }
 
 /// Represents a TES task monitor.
@@ -93,7 +94,7 @@ impl TaskMonitor {
     /// Returns the tag to use when creating the TES task.
     pub async fn add_task(
         &self,
-        id: u64,
+        id: TaskId,
         name: String,
         completed: oneshot::Sender<Result<()>>,
     ) -> String {
@@ -120,7 +121,7 @@ impl TaskMonitor {
     /// Associates a TES task id with a Crankshaft task id.
     ///
     /// This is called after the TES task has been created.
-    pub async fn associate_task_id(&self, id: u64, tes_id: String) {
+    pub async fn associate_task_id(&self, id: TaskId, tes_id: String) {
         let mut state = self.state.lock().expect("failed to lock TES monitor state");
         state.ids.insert(tes_id, id);
     }

--- a/crankshaft-events/CHANGELOG.md
+++ b/crankshaft-events/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Added
 
-* Added `ImagePullStarted`, `ImagePullFinished`, and `ImagePullFailed` events ([#](https://github.com/stjude-rust-labs/crankshaft/pull/)).
+* Added `ImagePullStarted`, `ImagePullFinished`, and `ImagePullFailed` events ([#82](https://github.com/stjude-rust-labs/crankshaft/pull/82)).
 
 ## 0.1.0 - 09-03-2025
 

--- a/crankshaft-events/CHANGELOG.md
+++ b/crankshaft-events/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+#### Added
+
+* Added `ImagePullStarted`, `ImagePullFinished`, and `ImagePullFailed` events ([#](https://github.com/stjude-rust-labs/crankshaft/pull/)).
+
 ## 0.1.0 - 09-03-2025
 
 #### Added

--- a/crankshaft-events/src/lib.rs
+++ b/crankshaft-events/src/lib.rs
@@ -8,8 +8,11 @@ use bytes::Bytes;
 use nonempty::NonEmpty;
 use tokio_util::sync::CancellationToken;
 
+/// Represents a Crankshaft task identifier.
+pub type TaskId = u64;
+
 /// Gets the next task id.
-pub fn next_task_id() -> u64 {
+pub fn next_task_id() -> TaskId {
     static NEXT_TASK_ID: AtomicU64 = AtomicU64::new(0);
     NEXT_TASK_ID.fetch_add(1, Ordering::SeqCst)
 }
@@ -25,7 +28,7 @@ pub enum Event {
     /// `TaskCanceled`, or `TaskPreempted` event.
     TaskCreated {
         /// The id of the task.
-        id: u64,
+        id: TaskId,
         /// The name of the task.
         ///
         /// This may be a display name provided by the user or a name provided
@@ -44,14 +47,14 @@ pub enum Event {
     /// A task is considered "running" upon the receipt of this event.
     TaskStarted {
         /// The id of the task.
-        id: u64,
+        id: TaskId,
     },
     /// A container has been created for a task.
     ///
     /// This event is only sent by the Docker backend.
     TaskContainerCreated {
         /// The id of the task.
-        id: u64,
+        id: TaskId,
         /// The name of the container that was created.
         container: String,
     },
@@ -60,7 +63,7 @@ pub enum Event {
     /// This event is only sent by the Docker backend.
     TaskContainerExited {
         /// The id of the task.
-        id: u64,
+        id: TaskId,
         /// The name of the container that has exited.
         container: String,
         /// The exit status of the container.
@@ -71,7 +74,7 @@ pub enum Event {
     /// This event occurs after all task executions have completed successfully.
     TaskCompleted {
         /// The id of the task.
-        id: u64,
+        id: TaskId,
         /// The exit statuses for the task's executions.
         exit_statuses: NonEmpty<ExitStatus>,
     },
@@ -80,26 +83,26 @@ pub enum Event {
     /// This event occurs after any error encountered running a task.
     TaskFailed {
         /// The id of the task.
-        id: u64,
+        id: TaskId,
         /// The error message.
         message: String,
     },
     /// A task has been canceled.
     TaskCanceled {
         /// The id of the task.
-        id: u64,
+        id: TaskId,
     },
     /// The task was preempted.
     TaskPreempted {
         /// The id of the task.
-        id: u64,
+        id: TaskId,
     },
     /// A task has logged stdout.
     ///
     /// Note: only locally executing tasks will send this event.
     TaskStdout {
         /// The id of the task.
-        id: u64,
+        id: TaskId,
         /// The bytes logged to stdout.
         message: Bytes,
     },
@@ -108,21 +111,21 @@ pub enum Event {
     /// Note: only locally executing tasks will send this event.
     TaskStderr {
         /// The id of the task.
-        id: u64,
+        id: TaskId,
         /// The bytes logged to stdout.
         message: Bytes,
     },
     /// A container image pull was started.
     ImagePullStarted {
         /// The id of the task that triggered the pull.
-        id: u64,
+        id: TaskId,
         /// The name of the image being pulled.
         name: String,
     },
     /// Failed to pull a container image.
     ImagePullFailed {
         /// The id of the task that triggered the pull.
-        id: u64,
+        id: TaskId,
         /// The name of the image that failed.
         name: String,
         /// The error message.
@@ -131,7 +134,7 @@ pub enum Event {
     /// A container image was successfully pulled.
     ImagePullFinished {
         /// The id of the task that triggered the pull.
-        id: u64,
+        id: TaskId,
         /// The name of the image that was pulled.
         name: String,
     },

--- a/crankshaft-events/src/lib.rs
+++ b/crankshaft-events/src/lib.rs
@@ -112,6 +112,29 @@ pub enum Event {
         /// The bytes logged to stdout.
         message: Bytes,
     },
+    /// A container image pull was started.
+    ImagePullStarted {
+        /// The id of the task that triggered the pull.
+        id: u64,
+        /// The name of the image being pulled.
+        name: String,
+    },
+    /// Failed to pull a container image.
+    ImagePullFailed {
+        /// The id of the task that triggered the pull.
+        id: u64,
+        /// The name of the image that failed.
+        name: String,
+        /// The error message.
+        message: String,
+    },
+    /// A container image was successfully pulled.
+    ImagePullFinished {
+        /// The id of the task that triggered the pull.
+        id: u64,
+        /// The name of the image that was pulled.
+        name: String,
+    },
 }
 
 /// Sends an event through a broadcast channel.

--- a/crankshaft-monitor/CHANGELOG.md
+++ b/crankshaft-monitor/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+* Added support for the `ImagePull{Started,Failed,Finished}` events ([#](https://github.com/stjude-rust-labs/crankshaft/pull/)).
+
 ## 0.2.0 - 02-11-2026
 
 ### Changed

--- a/crankshaft-monitor/CHANGELOG.md
+++ b/crankshaft-monitor/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* Added support for the `ImagePull{Started,Failed,Finished}` events ([#](https://github.com/stjude-rust-labs/crankshaft/pull/)).
+* Added support for the `ImagePull{Started,Failed,Finished}` events ([#82](https://github.com/stjude-rust-labs/crankshaft/pull/82)).
 
 ## 0.2.0 - 02-11-2026
 

--- a/crankshaft-monitor/src/proto/crankshaft.monitor.rs
+++ b/crankshaft-monitor/src/proto/crankshaft.monitor.rs
@@ -39,7 +39,10 @@ pub struct Event {
     /// The timestamp of the event.
     #[prost(message, optional, tag = "1")]
     pub timestamp: ::core::option::Option<::prost_types::Timestamp>,
-    #[prost(oneof = "event::EventKind", tags = "2, 3, 4, 5, 6, 7, 8, 9, 10, 11")]
+    #[prost(
+        oneof = "event::EventKind",
+        tags = "2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14"
+    )]
     pub event_kind: ::core::option::Option<event::EventKind>,
 }
 /// Nested message and enum types in `Event`.
@@ -77,6 +80,15 @@ pub mod event {
         /// The task stderr event.
         #[prost(message, tag = "11")]
         Stderr(super::TaskStderrEvent),
+        /// The image pull event.
+        #[prost(message, tag = "12")]
+        ImagePullStarted(super::ImagePullStartedEvent),
+        /// The image pull failed event.
+        #[prost(message, tag = "13")]
+        ImagePullFailed(super::ImagePullFailedEvent),
+        /// The image pull finished event.
+        #[prost(message, tag = "14")]
+        ImagePullFinished(super::ImagePullFinishedEvent),
     }
 }
 /// Represents an exit status.
@@ -211,6 +223,42 @@ pub struct TaskStderrEvent {
     /// The stderr message.
     #[prost(bytes = "vec", tag = "2")]
     pub message: ::prost::alloc::vec::Vec<u8>,
+}
+/// Represents an image pull event.
+#[allow(clippy::all, missing_docs, clippy::missing_docs_in_private_items)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct ImagePullStartedEvent {
+    /// The id of the task that triggered the pull.
+    #[prost(uint64, tag = "1")]
+    pub id: u64,
+    /// The name of the image being pulled.
+    #[prost(string, tag = "2")]
+    pub name: ::prost::alloc::string::String,
+}
+/// Represents an image pull finished event.
+#[allow(clippy::all, missing_docs, clippy::missing_docs_in_private_items)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct ImagePullFailedEvent {
+    /// The id of the task that triggered the pull.
+    #[prost(uint64, tag = "1")]
+    pub id: u64,
+    /// The name of the image that was pulled.
+    #[prost(string, tag = "2")]
+    pub name: ::prost::alloc::string::String,
+    /// The error message.
+    #[prost(string, tag = "3")]
+    pub message: ::prost::alloc::string::String,
+}
+/// Represents an image pull finished event.
+#[allow(clippy::all, missing_docs, clippy::missing_docs_in_private_items)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct ImagePullFinishedEvent {
+    /// The id of the task that triggered the pull.
+    #[prost(uint64, tag = "1")]
+    pub id: u64,
+    /// The name of the image that was pulled.
+    #[prost(string, tag = "2")]
+    pub name: ::prost::alloc::string::String,
 }
 /// Generated client implementations.
 #[allow(clippy::all, missing_docs, clippy::missing_docs_in_private_items)]

--- a/crankshaft-monitor/src/proto/monitor.proto
+++ b/crankshaft-monitor/src/proto/monitor.proto
@@ -63,6 +63,12 @@ message Event {
     TaskStdoutEvent stdout = 10;
     // The task stderr event.
     TaskStderrEvent stderr = 11;
+    // The image pull event.
+    ImagePullStartedEvent image_pull_started = 12;
+    // The image pull failed event.
+    ImagePullFailedEvent image_pull_failed = 13;
+    // The image pull finished event.
+    ImagePullFinishedEvent image_pull_finished = 14;
   }
 }
 
@@ -158,4 +164,30 @@ message TaskStderrEvent {
   uint64 id = 1;
   // The stderr message.
   bytes message = 2;
+}
+
+// Represents an image pull event.
+message ImagePullStartedEvent {
+  // The id of the task that triggered the pull.
+  uint64 id = 1;
+  // The name of the image being pulled.
+  string name = 2;
+}
+
+// Represents an image pull finished event.
+message ImagePullFailedEvent {
+  // The id of the task that triggered the pull.
+  uint64 id = 1;
+  // The name of the image that was pulled.
+  string name = 2;
+  // The error message.
+  string message = 3;
+}
+
+// Represents an image pull finished event.
+message ImagePullFinishedEvent {
+  // The id of the task that triggered the pull.
+  uint64 id = 1;
+  // The name of the image that was pulled.
+  string name = 2;
 }

--- a/crankshaft-monitor/src/service.rs
+++ b/crankshaft-monitor/src/service.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use std::time::SystemTime;
 
 use crankshaft_events::Event as CrankshaftEvent;
+use crankshaft_events::TaskId;
 use futures_core::Stream;
 use tokio::sync::RwLock;
 use tokio::sync::broadcast;
@@ -42,9 +43,6 @@ use crate::proto::TaskStdoutEvent;
 use crate::proto::event::EventKind;
 use crate::proto::exit_status::ExitStatusKind;
 use crate::proto::monitor_server::Monitor;
-
-/// Represents a task identifier.
-pub type TaskId = u64;
 
 /// Helper trait for converting Crankshaft types into Protobuf types.
 trait IntoProtobuf<T> {

--- a/crankshaft-monitor/src/service.rs
+++ b/crankshaft-monitor/src/service.rs
@@ -22,6 +22,9 @@ use crate::proto::CancelTaskRequest;
 use crate::proto::CancelTaskResponse;
 use crate::proto::Event;
 use crate::proto::ExitStatus;
+use crate::proto::ImagePullFailedEvent;
+use crate::proto::ImagePullFinishedEvent;
+use crate::proto::ImagePullStartedEvent;
 use crate::proto::ServiceStateRequest;
 use crate::proto::ServiceStateResponse;
 use crate::proto::SubscribeEventsRequest;
@@ -118,6 +121,15 @@ impl IntoProtobuf<EventKind> for CrankshaftEvent {
                 id,
                 message: message.to_vec(),
             }),
+            CrankshaftEvent::ImagePullStarted { id, name } => {
+                EventKind::ImagePullStarted(ImagePullStartedEvent { id, name })
+            }
+            CrankshaftEvent::ImagePullFailed { id, name, message } => {
+                EventKind::ImagePullFailed(ImagePullFailedEvent { id, name, message })
+            }
+            CrankshaftEvent::ImagePullFinished { id, name } => {
+                EventKind::ImagePullFinished(ImagePullFinishedEvent { id, name })
+            }
         }
     }
 }
@@ -177,6 +189,7 @@ impl MonitorService {
                 r = events.recv() => match r {
                     Ok(event) => {
                         let (id, remove) = match event {
+                            CrankshaftEvent::ImagePullStarted { .. } | CrankshaftEvent::ImagePullFailed { .. } | CrankshaftEvent::ImagePullFinished { .. } => continue,
                             CrankshaftEvent::TaskCreated { id, .. } |
                             CrankshaftEvent::TaskStarted { id }
                             | CrankshaftEvent::TaskContainerCreated { id, .. }


### PR DESCRIPTION
This adds generic `ImagePullStarted`, `ImagePullFinished`, and `ImagePullFailed` events and support in `crankshaft-docker`.

For https://github.com/stjude-rust-labs/sprocket/issues/363

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [ ] You have added yourself or the appropriate individual as the assignee.
- [ ] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [ ] You have added tests (when appropriate).
- [ ] You have updated the README or other documentation to account for these changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
