### PR TITLE
feat: per-execution fallback images

### DIFF
--- a/crankshaft-docker/src/bin/docker-driver.rs
+++ b/crankshaft-docker/src/bin/docker-driver.rs
@@ -137,9 +137,9 @@ async fn run(args: Args) -> Result<()> {
 
             let container =
                 create_container(docker, image, tag, &name, command.remove(0), args).await?;
-            let status = container.run(&name, None).await?;
+            let result = container.run(&name, None).await?;
 
-            println!("exit code: {status}");
+            println!("exit code: {}", result.status);
         }
         Command::RemoveContainer { name, force } => {
             let container = docker.container_from_name(name, None, None);

--- a/crankshaft-docker/src/container.rs
+++ b/crankshaft-docker/src/container.rs
@@ -149,6 +149,14 @@ pub(crate) async fn write_logs(
     Ok(())
 }
 
+/// The result of a [`Container`] run.
+pub struct ExecutionResult {
+    /// The name of the container image that was used in this execution.
+    pub image: String,
+    /// The exit status of the execution.
+    pub status: ExitStatus,
+}
+
 /// A container.
 pub struct Container {
     /// A reference to the [`Docker`] client that will be used to create this
@@ -190,7 +198,11 @@ impl Container {
     }
 
     /// Runs a container and waits for the execution to end.
-    pub async fn run(&self, task_name: &str, events: Option<EventOptions>) -> Result<ExitStatus> {
+    pub async fn run(
+        &self,
+        task_name: &str,
+        events: Option<EventOptions>,
+    ) -> Result<ExecutionResult> {
         if let Some(events) = &events {
             events
                 .sender
@@ -207,6 +219,13 @@ impl Container {
         );
 
         // Start the container.
+
+        let inspect_response = default_retry(|| {
+            self.client
+                .inspect_container(&self.name, None::<InspectContainerOptions>)
+        })
+        .await
+        .map_err(Error::Docker)?;
 
         default_retry(|| {
             self.client
@@ -338,7 +357,12 @@ impl Container {
                 .ok();
         }
 
-        Ok(status)
+        Ok(ExecutionResult {
+            image: inspect_response
+                .image
+                .expect("Docker reported a container without an image"),
+            status,
+        })
     }
 
     /// Removes a container with the level of force specified.

--- a/crankshaft-docker/src/service.rs
+++ b/crankshaft-docker/src/service.rs
@@ -31,6 +31,7 @@ use tracing::trace;
 use crate::Error;
 use crate::EventOptions;
 use crate::Result;
+use crate::container::ExecutionResult;
 use crate::container::write_logs;
 
 /// A docker service.
@@ -82,7 +83,11 @@ impl Service {
     }
 
     /// Runs a service and waits for the task execution to end.
-    pub async fn run(&self, task_name: &str, events: Option<EventOptions>) -> Result<ExitStatus> {
+    pub async fn run(
+        &self,
+        task_name: &str,
+        events: Option<EventOptions>,
+    ) -> Result<ExecutionResult> {
         let stdout = match &self.stdout {
             Some(path) => Some((
                 path.as_path(),
@@ -109,7 +114,7 @@ impl Service {
             None => None,
         };
 
-        let (container_id, exit_code) = loop {
+        let (image, container_id, exit_code) = loop {
             trace!(
                 "polling tasks for service `{id}` (task `{task_name}`)",
                 id = self.id
@@ -140,6 +145,12 @@ impl Service {
             );
 
             let task = tasks.into_iter().next().unwrap();
+            let image = task
+                .spec
+                .as_ref()
+                .and_then(|spec| spec.container_spec.as_ref())
+                .and_then(|spec| spec.image.clone())
+                .expect("Docker reported a container without a state");
 
             let status = task.status.ok_or_else(|| {
                 Error::Message("Docker daemon reported a task with no status".into())
@@ -234,7 +245,7 @@ impl Service {
                                 code,
                                 ..
                             })) => {
-                                break (container_id, code);
+                                break (image, container_id, code);
                             }
                             Some(Err(e)) => return Err(e.into()),
                             None => {
@@ -249,6 +260,7 @@ impl Service {
                                     .map_err(Error::Docker)?;
 
                                 break (
+                                    image,
                                     container_id,
                                     container
                                         .state
@@ -271,6 +283,7 @@ impl Service {
                         }
                     } else {
                         break (
+                            image,
                             container_id,
                             container_status.exit_code.ok_or_else(|| {
                                 Error::Message(format!(
@@ -325,7 +338,7 @@ impl Service {
                 .ok();
         }
 
-        Ok(status)
+        Ok(ExecutionResult { image, status })
     }
 
     /// Deletes a service.

--- a/crankshaft-engine/CHANGELOG.md
+++ b/crankshaft-engine/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+* `Execution`s can now specify multiple container images to act as fallbacks ([#83](https://github.com/stjude-rust-labs/crankshaft/pull/83)).
+* `Backend::run()` now returns a collection of `ExecutionResult`s, rather than `ExitStatus` ([#83](https://github.com/stjude-rust-labs/crankshaft/pull/83)).
+
 ## 0.10.0 - 04-22-2026
 
 ### Added

--- a/crankshaft-engine/src/service/runner.rs
+++ b/crankshaft-engine/src/service/runner.rs
@@ -1,6 +1,5 @@
 //! Task runner services.
 
-use std::process::ExitStatus;
 use std::sync::Arc;
 use std::sync::Mutex;
 
@@ -25,19 +24,20 @@ use crate::service::name::UniqueAlphanumeric;
 use crate::service::runner::backend::docker;
 use crate::service::runner::backend::generic;
 use crate::service::runner::backend::tes;
+use crate::task::ExecutionResult;
 
 /// The size of the name buffer.
 const NAME_BUFFER_LEN: usize = 4096;
 
 /// A spawned task handle.
 #[derive(Debug)]
-pub struct TaskHandle(Receiver<Result<NonEmpty<ExitStatus>, backend::TaskRunError>>);
+pub struct TaskHandle(Receiver<Result<NonEmpty<ExecutionResult>, backend::TaskRunError>>);
 
 impl TaskHandle {
     /// Consumes the task handle and waits for the task to complete.
     ///
     /// Returns the exit statuses of the task's executors.
-    pub async fn wait(self) -> Result<NonEmpty<ExitStatus>, backend::TaskRunError> {
+    pub async fn wait(self) -> Result<NonEmpty<ExecutionResult>, backend::TaskRunError> {
         self.0
             .await
             .map_err(|e| backend::TaskRunError::Other(e.into()))?

--- a/crankshaft-engine/src/service/runner/backend.rs
+++ b/crankshaft-engine/src/service/runner/backend.rs
@@ -1,7 +1,6 @@
 //! Supported backends.
 
 use std::fmt::Debug;
-use std::process::ExitStatus;
 
 use anyhow::Result;
 use async_trait::async_trait;
@@ -10,6 +9,7 @@ use nonempty::NonEmpty;
 use tokio_util::sync::CancellationToken;
 
 use crate::Task;
+use crate::task::execution::ExecutionResult;
 
 pub mod docker;
 pub mod generic;
@@ -49,5 +49,5 @@ pub trait Backend: Debug + Send + Sync + 'static {
         &self,
         task: Task,
         token: CancellationToken,
-    ) -> Result<BoxFuture<'static, Result<NonEmpty<ExitStatus>, TaskRunError>>>;
+    ) -> Result<BoxFuture<'static, Result<NonEmpty<ExecutionResult>, TaskRunError>>>;
 }

--- a/crankshaft-engine/src/service/runner/backend/docker.rs
+++ b/crankshaft-engine/src/service/runner/backend/docker.rs
@@ -2,7 +2,6 @@
 
 use std::path::Path;
 use std::path::PathBuf;
-use std::process::ExitStatus;
 use std::sync::Arc;
 use std::sync::Mutex;
 
@@ -23,6 +22,7 @@ use crankshaft_docker::Docker;
 use crankshaft_docker::EventOptions;
 use crankshaft_docker::service::Service;
 use crankshaft_events::Event;
+use crankshaft_events::TaskId;
 use crankshaft_events::next_task_id;
 use crankshaft_events::send_event;
 use futures::FutureExt;
@@ -39,7 +39,18 @@ use super::TaskRunError;
 use crate::Task;
 use crate::service::name::GeneratorIterator;
 use crate::service::name::UniqueAlphanumeric;
+use crate::task::Execution;
+use crate::task::ExecutionResult;
 use crate::task::Input;
+
+impl From<crankshaft_docker::container::ExecutionResult> for ExecutionResult {
+    fn from(execution_result: crankshaft_docker::container::ExecutionResult) -> Self {
+        Self {
+            image: Some(execution_result.image),
+            status: execution_result.status,
+        }
+    }
+}
 
 /// Represents resource information about a Docker swarm.
 #[derive(Debug, Default, Clone, Copy)]
@@ -368,6 +379,40 @@ impl Cleanup {
     }
 }
 
+/// Attempt to find a candidate image for the given execution.
+async fn find_candidate_image(
+    client: &Docker,
+    execution: &Execution,
+    token: CancellationToken,
+    events: Option<broadcast::Sender<Event>>,
+    task_id: TaskId,
+) -> Result<String, TaskRunError> {
+    let total_images = execution.images().len();
+    let events = events.map(|e| (e, task_id));
+
+    for (idx, try_image) in execution.images().iter().cloned().enumerate() {
+        match client
+            .ensure_image(&try_image, token.clone(), events.clone())
+            .await
+            .with_context(|| format!("failed to pull image `{try_image}`"))
+        {
+            Ok(Some(())) => {
+                return Ok(try_image);
+            }
+            Ok(None) => return Err(TaskRunError::Canceled),
+            Err(e) => {
+                if idx == total_images - 1 {
+                    return Err(TaskRunError::from(e));
+                }
+
+                continue;
+            }
+        }
+    }
+
+    unreachable!("there should always be at least one image available")
+}
+
 #[async_trait]
 impl crate::Backend for Backend {
     fn default_name(&self) -> &'static str {
@@ -378,7 +423,7 @@ impl crate::Backend for Backend {
         &self,
         task: Task,
         token: CancellationToken,
-    ) -> Result<BoxFuture<'static, Result<NonEmpty<ExitStatus>, TaskRunError>>> {
+    ) -> Result<BoxFuture<'static, Result<NonEmpty<ExecutionResult>, TaskRunError>>> {
         let task_id = next_task_id();
         let client = self.client.clone();
         let run_cleanup = self.config.cleanup();
@@ -397,7 +442,6 @@ impl crate::Backend for Backend {
                 generator.next().unwrap()
             });
 
-            let events_ctx = events.clone().map(|e| (e, task_id));
             let run = async {
                 let tempdir = TempDir::new().context("failed to create temporary directory for mounts")?;
 
@@ -411,15 +455,8 @@ impl crate::Backend for Backend {
                         return Err(TaskRunError::Canceled);
                     }
 
-                    // First ensure the execution's image exists
-                    match client
-                        .ensure_image(&execution.image, token.clone(), events_ctx.clone())
-                        .await
-                        .with_context(|| format!("failed to pull image `{image}`", image = execution.image))?
-                    {
-                        Some(()) => {}
-                        None => return Err(TaskRunError::Canceled),
-                    }
+                    // First, ensure the execution's image exists
+                    let image = find_candidate_image(&client, &execution, token.clone(), events.clone(), task_id).await?;
 
                     // Look for the path where the caller wants stdout saved to
                     let stdout = execution.stdout.as_ref().and_then(|p| {
@@ -479,7 +516,7 @@ impl crate::Backend for Backend {
                         let mut builder = client
                             .service_builder()
                             .name(&name)
-                            .image(execution.image)
+                            .image(image)
                             .program(execution.program)
                             .args(execution.args)
                             .envs(execution.env)
@@ -518,7 +555,7 @@ impl crate::Backend for Backend {
                         let mut builder = client
                             .container_builder()
                             .name(&name)
-                            .image(execution.image)
+                            .image(image)
                             .program(execution.program)
                             .args(execution.args)
                             .envs(execution.env)
@@ -581,18 +618,22 @@ impl crate::Backend for Backend {
             };
 
             // Send the created event
-            send_event!(events, Event::TaskCreated { id: task_id, name: task_name.clone(), tes_id: None, token:task_token.clone()  });
+            send_event!(events, Event::TaskCreated { id: task_id, name: task_name.clone(), tes_id: None, token: task_token.clone() });
 
             // Run the task to completion
-            let result = run.await;
+            let result: Result<NonEmpty<ExecutionResult>, _> = run.await.map(|results| {
+                // SAFETY: NonEmpty -> NonEmpty
+                NonEmpty::collect(results.into_iter().map(Into::into)).unwrap()
+            });
 
             // Send an event for the result
             match &result {
-                Ok(statuses) => send_event!(
+                Ok(results) => send_event!(
                     events,
                     Event::TaskCompleted {
                         id: task_id,
-                        exit_statuses: statuses.clone(),
+                        // SAFETY: NonEmpty -> NonEmpty
+                        exit_statuses: NonEmpty::collect(results.iter().map(|r| r.status)).unwrap(),
                     }
                 ),
                 Err(TaskRunError::Canceled) => send_event!(
@@ -696,21 +737,32 @@ fn add_shared_mounts(volumes: Vec<String>, tempdir: &Path, mounts: &mut Vec<Moun
 
 #[cfg(test)]
 mod test {
+    use std::fs;
     use std::io::Write;
     use std::ops::Deref;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
 
     use anyhow::Context;
+    use tempfile::NamedTempFile;
+    use url::Url;
 
     use super::*;
+    use crate::service::runner::Backend;
     use crate::service::runner::NAME_BUFFER_LEN;
+    use crate::task::Output;
     use crate::task::output::Type;
 
     struct BackendTest {
-        backend: Backend,
+        backend: super::Backend,
+        image_pull_fails: Arc<AtomicUsize>,
     }
 
     impl BackendTest {
-        async fn redirect_stdio(mut event_rx: broadcast::Receiver<Event>) -> anyhow::Result<()> {
+        async fn redirect_stdio(
+            mut event_rx: broadcast::Receiver<Event>,
+            image_pull_fails: Arc<AtomicUsize>,
+        ) -> anyhow::Result<()> {
             while let Ok(event) = event_rx.recv().await {
                 match event {
                     Event::TaskStdout { message, .. } => {
@@ -726,6 +778,9 @@ mod test {
                     Event::TaskFailed { message, .. } => {
                         eprintln!("{message}");
                     }
+                    Event::ImagePullFailed { .. } => {
+                        image_pull_fails.fetch_add(1, Ordering::Relaxed);
+                    }
                     _ => {}
                 }
             }
@@ -739,19 +794,23 @@ mod test {
                 NAME_BUFFER_LEN,
             )));
 
+            let image_pull_fails = Arc::new(AtomicUsize::new(0));
             let (event_tx, event_rx) = broadcast::channel(1024);
-            tokio::task::spawn(Self::redirect_stdio(event_rx));
+            tokio::task::spawn(Self::redirect_stdio(event_rx, image_pull_fails.clone()));
 
-            let backend = Backend::initialize_default_with(config, names, Some(event_tx))
+            let backend = super::Backend::initialize_default_with(config, names, Some(event_tx))
                 .await
                 .context("failed to create backend")?;
 
-            Ok(Self { backend })
+            Ok(Self {
+                backend,
+                image_pull_fails,
+            })
         }
     }
 
     impl Deref for BackendTest {
-        type Target = Backend;
+        type Target = super::Backend;
 
         fn deref(&self) -> &Self::Target {
             &self.backend
@@ -783,12 +842,12 @@ mod test {
             .into_temp_path();
 
         // Run the task
-        let statuses = backend
+        let results = backend
             .run(
                 Task::builder()
                     .executions(NonEmpty::new(
                         Execution::builder()
-                            .image("ubuntu:latest")
+                            .images(["ubuntu:latest"])?
                             .program("/bin/sh")
                             .args([String::from("-c"), String::from("/usr/bin/id -G")])
                             .stdout("/mnt/stdout")
@@ -811,7 +870,7 @@ mod test {
             .await
             .context("task execution failed")?;
 
-        assert!(statuses.first().success(), "container failed");
+        assert!(results.first().status.success(), "container failed");
 
         // Assert that the command output had the user's group added
         let stdout = fs::read_to_string(&stdout_path).context("failed to read stdout file")?;
@@ -819,6 +878,63 @@ mod test {
             stdout.contains(&gid.to_string()),
             "task stdout of `{stdout}` did not contain the expected output"
         );
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[cfg(target_os = "linux")]
+    async fn backend_supports_fallback_images() -> anyhow::Result<()> {
+        let backend = BackendTest::new(Config::default()).await?;
+
+        let stdout_path = NamedTempFile::new()
+            .context("failed to create temporary file")?
+            .into_temp_path();
+
+        let results = backend
+            .run(
+                Task::builder()
+                    .executions(NonEmpty::new(
+                        Execution::builder()
+                            .images([
+                                "ubuntu:super_fake_tag_that_doesnt_exist",
+                                "ubuntu:this_tag_is_even_more_fake",
+                                "ubuntu:latest",
+                            ])?
+                            .program("/bin/sh")
+                            .args([
+                                String::from("-c"),
+                                String::from("/usr/bin/echo \"Hello, world!\""),
+                            ])
+                            .stdout("/mnt/stdout")
+                            .build(),
+                    ))
+                    .outputs(vec![
+                        Output::builder()
+                            .ty(Type::File)
+                            .path("/mnt/stdout")
+                            .url(
+                                Url::from_file_path(&stdout_path)
+                                    .expect("failed to get URL for stdout path"),
+                            )
+                            .build(),
+                    ])
+                    .build(),
+                CancellationToken::new(),
+            )
+            .context("failed to run task")?
+            .await
+            .context("task execution failed")?;
+
+        assert!(results.first().status.success(), "container failed");
+        assert_eq!(backend.image_pull_fails.load(Ordering::Relaxed), 2);
+
+        // Assert that the command was run
+        let stdout = fs::read_to_string(&stdout_path).context("failed to read stdout file")?;
+        assert!(
+            stdout.contains("Hello, world!"),
+            "task stdout of `{stdout}` did not contain the expected output"
+        );
+
         Ok(())
     }
 }

--- a/crankshaft-engine/src/service/runner/backend/generic.rs
+++ b/crankshaft-engine/src/service/runner/backend/generic.rs
@@ -3,7 +3,6 @@
 //! Generic backends are intended to be relatively malleable and configurable by
 //! the end user without requiring the need to write Rust code.
 
-use std::process::ExitStatus;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::time::Duration;
@@ -29,6 +28,7 @@ use crate::Task;
 use crate::service::name::GeneratorIterator;
 use crate::service::name::UniqueAlphanumeric;
 use crate::service::runner::backend::generic::driver::Driver;
+use crate::task::ExecutionResult;
 use crate::task::Resources;
 
 pub mod driver;
@@ -117,7 +117,7 @@ impl crate::Backend for Backend {
         &self,
         task: Task,
         token: CancellationToken,
-    ) -> Result<BoxFuture<'static, Result<NonEmpty<ExitStatus>, TaskRunError>>> {
+    ) -> Result<BoxFuture<'static, Result<NonEmpty<ExecutionResult>, TaskRunError>>> {
         let driver = self.driver.clone();
         let config = self.config.clone();
 
@@ -141,7 +141,7 @@ impl crate::Backend for Backend {
             });
 
             let run = async {
-                let mut statuses = Vec::new();
+                let mut results = Vec::new();
                 let job_id_regex = config
                     .job_id_regex()
                     .as_ref()
@@ -160,9 +160,9 @@ impl crate::Backend for Backend {
                     // change the model of how tasks are done internally to remove
                     // this need.
                     warn!(
-                        "generic backends do not support images; as such, the directive to use a \
-                         `{}` image will be ignored",
-                        execution.image
+                        "generic backends do not support images; as such, the directive to use \
+                         the images: `{:?}` will be ignored",
+                        execution.images()
                     );
 
                     let mut substitutions = default_substitutions.clone();
@@ -249,7 +249,10 @@ impl crate::Backend for Backend {
 
                                 let output = result?;
                                 if !output.status.success() {
-                                    statuses.push(output.status);
+                                    results.push(ExecutionResult {
+                                        image: None,
+                                        status: output.status,
+                                    });
                                     break;
                                 }
 
@@ -262,14 +265,17 @@ impl crate::Backend for Backend {
                             }
                         }
                         None => {
-                            statuses.push(output.status);
+                            results.push(ExecutionResult {
+                                image: None,
+                                status: output.status,
+                            });
                         }
                     }
                 }
 
                 // SAFETY: each task _must_ have at least one execution, so at least one
                 // execution result _must_ exist at this stage. Thus, this will always unwrap.
-                Ok(NonEmpty::from_vec(statuses).unwrap())
+                Ok(NonEmpty::from_vec(results).unwrap())
             };
 
             // Send the created event
@@ -284,15 +290,16 @@ impl crate::Backend for Backend {
             );
 
             // Run the task to completion
-            let result = run.await;
+            let results = run.await;
 
             // Send an event for the result
-            match &result {
-                Ok(statuses) => send_event!(
+            match &results {
+                Ok(results) => send_event!(
                     events,
                     Event::TaskCompleted {
                         id: task_id,
-                        exit_statuses: statuses.clone()
+                        // SAFETY: NonEmpty -> NonEmpty
+                        exit_statuses: NonEmpty::collect(results.iter().map(|r| r.status)).unwrap(),
                     }
                 ),
                 Err(TaskRunError::Canceled) => {
@@ -310,7 +317,7 @@ impl crate::Backend for Backend {
                 ),
             }
 
-            result
+            results
         }
         .boxed())
     }

--- a/crankshaft-engine/src/service/runner/backend/tes.rs
+++ b/crankshaft-engine/src/service/runner/backend/tes.rs
@@ -42,6 +42,7 @@ use crate::Task;
 use crate::service::name::GeneratorIterator;
 use crate::service::name::UniqueAlphanumeric;
 use crate::service::runner::backend::tes::monitor::TaskMonitor;
+use crate::task::ExecutionResult;
 
 mod monitor;
 
@@ -164,7 +165,7 @@ impl Backend {
         task_name: &str,
         tes_id: &str,
         completed: oneshot::Receiver<Result<()>>,
-    ) -> Result<NonEmpty<ExitStatus>, TaskRunError> {
+    ) -> Result<NonEmpty<ExecutionResult>, TaskRunError> {
         info!(
             "TES task `{tes_id}` (task `{task_name}`) has been created; waiting for task to start"
         );
@@ -220,24 +221,30 @@ impl Backend {
                 // There may be multiple task logs due to internal retries by the TES server
                 // Therefore, we're only interested in the last log
                 let logs = task.logs.unwrap_or_default();
-                let task = logs.last().context(
+                let task_log = logs.last().context(
                     "invalid response from TES server: completed task is missing task logs",
                 )?;
 
                 // Iterate the exit code from each executor log
-                Ok(NonEmpty::collect(task.logs.iter().map(|executor| {
-                    // See WEXITSTATUS from wait(2) to explain the shift
-                    #[cfg(unix)]
-                    let status = ExitStatus::from_raw(executor.exit_code << 8);
+                Ok(
+                    NonEmpty::collect(task_log.logs.iter().enumerate().map(|(idx, executor)| {
+                        // See WEXITSTATUS from wait(2) to explain the shift
+                        #[cfg(unix)]
+                        let status = ExitStatus::from_raw(executor.exit_code << 8);
 
-                    #[cfg(windows)]
-                    let status = ExitStatus::from_raw(executor.exit_code as u32);
+                        #[cfg(windows)]
+                        let status = ExitStatus::from_raw(executor.exit_code as u32);
 
-                    status
-                }))
-                .context(
-                    "invalid response from TES server: completed task is missing executor logs",
-                )?)
+                        ExecutionResult {
+                            // Realistically, the executor for any given log should always exist
+                            image: task.executors.get(idx).map(|e| e.image.clone()),
+                            status,
+                        }
+                    }))
+                    .context(
+                        "invalid response from TES server: completed task is missing executor logs",
+                    )?,
+                )
             }
             TesState::SystemError => {
                 info!("TES task `{tes_id}` (task `{task_name}`) has failed with a system error");
@@ -276,7 +283,7 @@ impl crate::Backend for Backend {
         &self,
         task: Task,
         token: CancellationToken,
-    ) -> Result<BoxFuture<'static, Result<NonEmpty<ExitStatus>, TaskRunError>>> {
+    ) -> Result<BoxFuture<'static, Result<NonEmpty<ExecutionResult>, TaskRunError>>> {
         let task_id = next_task_id();
         let names = self.names.clone();
         let monitor = self.monitor.clone();
@@ -369,11 +376,12 @@ impl crate::Backend for Backend {
 
             // Send an event for the result
             match &result {
-                Ok(statuses) => send_event!(
+                Ok(results) => send_event!(
                     state.events,
                     Event::TaskCompleted {
                         id: task_id,
-                        exit_statuses: statuses.clone(),
+                        // SAFETY: NonEmpty -> NonEmpty
+                        exit_statuses: NonEmpty::collect(results.iter().map(|r| r.status)).unwrap(),
                     }
                 ),
                 Err(TaskRunError::Canceled) => {

--- a/crankshaft-engine/src/task.rs
+++ b/crankshaft-engine/src/task.rs
@@ -13,6 +13,7 @@ pub mod output;
 pub mod resources;
 
 pub use execution::Execution;
+pub use execution::ExecutionResult;
 pub use input::Input;
 pub use output::Output;
 pub use resources::Resources;

--- a/crankshaft-engine/src/task/execution.rs
+++ b/crankshaft-engine/src/task/execution.rs
@@ -1,17 +1,39 @@
 //! A unit of executable work.
 
 use std::collections::BTreeMap;
+use std::fmt::Display;
+use std::process::ExitStatus;
 
 use bon::Builder;
 use indexmap::IndexMap;
+use nonempty::NonEmpty;
+
+/// An error used in [`Builder::images()`] when no images are specified.
+#[derive(Debug)]
+pub struct NoImageError;
+
+impl Display for NoImageError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "no image specified")
+    }
+}
+
+impl std::error::Error for NoImageError {}
 
 /// An execution.
 #[derive(Builder, Clone, Debug)]
 #[builder(builder_type = Builder)]
 pub struct Execution {
-    /// The container image.
-    #[builder(into)]
-    pub(crate) image: String,
+    /// The container images.
+    ///
+    /// For backends that support it, multiple images can be specified to act as
+    /// fallbacks in the event that the previous fails to pull.
+    ///
+    /// NOTE: Images will be tried in the order provided.
+    #[builder(with = |iter: impl IntoIterator<Item = impl Into<String>>| -> Result<_, NoImageError> {
+        NonEmpty::collect(iter.into_iter().map(Into::into)).ok_or(NoImageError)
+    })]
+    pub(crate) images: NonEmpty<String>,
 
     /// The program to execute.
     #[builder(into)]
@@ -46,9 +68,9 @@ pub struct Execution {
 }
 
 impl Execution {
-    /// The image for the execution to run within.
-    pub fn image(&self) -> &str {
-        &self.image
+    /// The images for the execution to run within.
+    pub fn images(&self) -> &NonEmpty<String> {
+        &self.images
     }
 
     /// The program to execute.
@@ -101,7 +123,7 @@ impl From<Execution> for tes::v1::types::task::Executor {
         command.extend(execution.args);
 
         tes::v1::types::task::Executor {
-            image: execution.image.to_owned(),
+            image: execution.images.first().into(),
             command,
             workdir: execution.work_dir,
             stdin: execution.stdin,
@@ -111,4 +133,16 @@ impl From<Execution> for tes::v1::types::task::Executor {
             ignore_error: Some(true),
         }
     }
+}
+
+/// The result of an [`Execution`].
+#[derive(Clone, Debug)]
+pub struct ExecutionResult {
+    /// The name of the container image that was used in this execution.
+    ///
+    /// NOTE: While [`Execution`]s require an image, a backend is not
+    /// necessarily required to make use of it.
+    pub image: Option<String>,
+    /// The exit status of the execution.
+    pub status: ExitStatus,
 }

--- a/examples/src/docker/main.rs
+++ b/examples/src/docker/main.rs
@@ -80,7 +80,7 @@ async fn run(args: Args, token: CancellationToken) -> Result<()> {
                         .display()
                         .to_string(),
                 )
-                .image("alpine")
+                .images(["alpine"])?
                 .program("echo")
                 .args([String::from("hello, world!")])
                 .stdout("/stdout")
@@ -164,9 +164,10 @@ async fn run(args: Args, token: CancellationToken) -> Result<()> {
 
     for (i, result) in results.into_iter().enumerate() {
         match result {
-            Ok((status, stdout, stderr)) => println!(
+            Ok((result, stdout, stderr)) => println!(
                 "task #{num} {status}, stdout: {stdout:?}, stderr: {stderr:?}",
                 num = i + 1,
+                status = result.status,
                 stdout = std::fs::read_to_string(&stdout).with_context(|| format!(
                     "failed to read stdout file `{stdout}`",
                     stdout = stdout.display()

--- a/examples/src/docker/monitored.rs
+++ b/examples/src/docker/monitored.rs
@@ -71,7 +71,7 @@ async fn run(args: Args, token: CancellationToken) -> Result<()> {
                         .display()
                         .to_string(),
                 )
-                .image("alpine")
+                .images(["alpine"])?
                 .program("sh")
                 .args([
                     String::from("-c"),
@@ -136,9 +136,10 @@ async fn run(args: Args, token: CancellationToken) -> Result<()> {
 
     for (i, result) in results.into_iter().enumerate() {
         match result {
-            Ok((status, stdout, stderr)) => println!(
+            Ok((result, stdout, stderr)) => println!(
                 "task #{num} {status}, stdout: {stdout:?}, stderr: {stderr:?}",
                 num = i + 1,
+                status = result.status,
                 stdout = std::fs::read_to_string(&stdout).with_context(|| format!(
                     "failed to read stdout file `{stdout}`",
                     stdout = stdout.display()

--- a/examples/src/lsf/main.rs
+++ b/examples/src/lsf/main.rs
@@ -84,7 +84,7 @@ async fn run(args: Args, token: CancellationToken) -> Result<()> {
                         .display()
                         .to_string(),
                 )
-                .image("alpine")
+                .images(["alpine"])?
                 .program("echo")
                 .args([String::from("hello, world!")])
                 .build(),
@@ -130,7 +130,11 @@ async fn run(args: Args, token: CancellationToken) -> Result<()> {
 
     for (i, result) in results.into_iter().enumerate() {
         match result {
-            Ok(output) => println!("task #{num} {status}", num = i + 1, status = output.first()),
+            Ok(output) => println!(
+                "task #{num} {status}",
+                num = i + 1,
+                status = output.first().status
+            ),
             Err(e) => println!("task #{num} failed: {e:#}", num = i + 1),
         }
     }

--- a/examples/src/tes/main.rs
+++ b/examples/src/tes/main.rs
@@ -98,7 +98,7 @@ async fn run(args: Args, token: CancellationToken) -> Result<()> {
                         .display()
                         .to_string(),
                 )
-                .image("alpine")
+                .images(["alpine"])?
                 .program("echo")
                 .args([String::from("hello, world!")])
                 .stdout("/stdout")
@@ -175,9 +175,10 @@ async fn run(args: Args, token: CancellationToken) -> Result<()> {
 
     for (i, result) in results.into_iter().enumerate() {
         match result {
-            Ok((status, stdout, stderr)) => println!(
+            Ok((result, stdout, stderr)) => println!(
                 "task #{num} {status}, stdout: {stdout:?}, stderr: {stderr:?}",
                 num = i + 1,
+                status = result.status,
                 stdout = std::fs::read_to_string(&stdout).with_context(|| format!(
                     "failed to read stdout file `{stdout}`",
                     stdout = stdout.display()


### PR DESCRIPTION
After #82, `Backend`s are now responsible for reporting image pull results. However, in `sprocket`, our wrapping `DockerBackend` was testing image candidates itself and passing the successful one to the `crankshaft` backend (which itself would test the image *again*): https://github.com/stjude-rust-labs/sprocket/blob/d6374fa88a816e37d01598121bbf4f4765d0e98c/crates/wdl-engine/src/backend/docker.rs#L689-L702

This now shifts the responsibility of image resolution to the `Backend`. The `Execution` builder takes a collection of images, and `Backend::run()` now returns `ExecutionResult`s that indicate both the exit code of the execution, as well as the image selected for that run.

@peterhuene (I can't assign reviewers)

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [ ] You have added yourself or the appropriate individual as the assignee.
- [ ] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [ ] You have updated the README or other documentation to account for these changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
