### PR TITLE
refactor: move events as an argument of running a task.

### DIFF
--- a/crankshaft-engine/CHANGELOG.md
+++ b/crankshaft-engine/CHANGELOG.md
@@ -10,6 +10,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+* Event channels are now passed to `run` instead of at the time of backend
+  construction ([#85](https://github.com/stjude-rust-labs/crankshaft/pull/85)).
 * `Execution`s can now specify multiple container images to act as fallbacks ([#83](https://github.com/stjude-rust-labs/crankshaft/pull/83)).
 * `Backend::run()` now returns a collection of `ExecutionResult`s, rather than `ExitStatus` ([#83](https://github.com/stjude-rust-labs/crankshaft/pull/83)).
 

--- a/crankshaft-engine/src/lib.rs
+++ b/crankshaft-engine/src/lib.rs
@@ -66,7 +66,7 @@ impl Engine {
     /// Adds a [`Backend`] to the engine.
     pub async fn with(mut self, config: Config) -> Result<Self> {
         let (name, kind, max_tasks, defaults) = config.into_parts();
-        let runner = Runner::initialize(kind, max_tasks, defaults, self.events.clone()).await?;
+        let runner = Runner::initialize(kind, max_tasks, defaults).await?;
         self.runners.insert(name, runner);
         Ok(self)
     }
@@ -125,7 +125,7 @@ impl Engine {
                 .unwrap_or_default(),
         );
 
-        backend.spawn(task, token).await
+        backend.spawn(task, self.events.clone(), token).await
     }
 
     /// Starts an instrumentation loop.

--- a/crankshaft-engine/src/service/runner.rs
+++ b/crankshaft-engine/src/service/runner.rs
@@ -59,7 +59,6 @@ impl Runner {
         config: Kind,
         max_tasks: usize,
         defaults: Option<Defaults>,
-        events: Option<broadcast::Sender<Event>>,
     ) -> Result<Self> {
         let names = Arc::new(Mutex::new(GeneratorIterator::new(
             UniqueAlphanumeric::default_with_expected_generations(NAME_BUFFER_LEN),
@@ -68,15 +67,14 @@ impl Runner {
 
         let backend = match config {
             Kind::Docker(config) => {
-                let backend =
-                    docker::Backend::initialize_default_with(config, names, events).await?;
+                let backend = docker::Backend::initialize_default_with(config, names).await?;
                 Arc::new(backend) as Arc<dyn Backend>
             }
             Kind::Generic(config) => {
-                let backend = generic::Backend::initialize(config, defaults, names, events).await?;
+                let backend = generic::Backend::initialize(config, defaults, names).await?;
                 Arc::new(backend)
             }
-            Kind::TES(config) => Arc::new(tes::Backend::initialize(config, names, events).await),
+            Kind::TES(config) => Arc::new(tes::Backend::initialize(config, names).await),
         };
 
         Ok(Self {
@@ -87,12 +85,17 @@ impl Runner {
 
     /// Spawns a task to be executed by the backend.
     ///
-    /// The `started` callback is called for each execution of the task that has
-    /// started; the parameter is the index of the execution from the task's
-    /// executions collection.
+    /// The optional `events` parameter is used to broadcast Crankshaft events
+    /// for the task's execution. Events are not broadcast when passed a `None`.
     ///
-    /// The `cancellation` token can be used to gracefully cancel the task.
-    pub async fn spawn(&self, task: Task, token: CancellationToken) -> anyhow::Result<TaskHandle> {
+    /// The `token` parameter is a cancellation token that can be used to cancel
+    /// the task's execution.
+    pub async fn spawn(
+        &self,
+        task: Task,
+        events: Option<broadcast::Sender<Event>>,
+        token: CancellationToken,
+    ) -> anyhow::Result<TaskHandle> {
         trace!(backend = ?self.backend, task = ?task);
 
         let (tx, rx) = tokio::sync::oneshot::channel();
@@ -101,7 +104,7 @@ impl Runner {
 
         tokio::spawn(async move {
             let _permit = lock.acquire().await?;
-            let result = backend.clone().run(task, token)?.await;
+            let result = backend.clone().run(task, events, token)?.await;
 
             // NOTE: if the send does not succeed, that is almost certainly
             // because the receiver was dropped. That is a relatively standard

--- a/crankshaft-engine/src/service/runner/backend.rs
+++ b/crankshaft-engine/src/service/runner/backend.rs
@@ -4,8 +4,10 @@ use std::fmt::Debug;
 
 use anyhow::Result;
 use async_trait::async_trait;
+use crankshaft_events::Event;
 use futures::future::BoxFuture;
 use nonempty::NonEmpty;
+use tokio::sync::broadcast;
 use tokio_util::sync::CancellationToken;
 
 use crate::Task;
@@ -40,14 +42,15 @@ pub trait Backend: Debug + Send + Sync + 'static {
 
     /// Runs a task in a backend.
     ///
-    /// The optional event_sender sends the task lifecycle events to any client
-    /// connected to `Crankshaft`
+    /// The optional `events` parameter is used to broadcast Crankshaft events
+    /// for the task's execution. Events are not broadcast when passed a `None`.
     ///
     /// Returns a collection of exit status corresponding to the task's
     /// executions.
     fn run(
         &self,
         task: Task,
+        events: Option<broadcast::Sender<Event>>,
         token: CancellationToken,
     ) -> Result<BoxFuture<'static, Result<NonEmpty<ExecutionResult>, TaskRunError>>>;
 }

--- a/crankshaft-engine/src/service/runner/backend/docker.rs
+++ b/crankshaft-engine/src/service/runner/backend/docker.rs
@@ -729,11 +729,9 @@ fn add_shared_mounts(volumes: Vec<String>, tempdir: &Path, mounts: &mut Vec<Moun
 #[cfg(target_os = "linux")]
 mod test {
     use std::fs;
-    use std::io::Write;
-    use std::sync::atomic::AtomicUsize;
-    use std::sync::atomic::Ordering;
 
     use anyhow::Context;
+    use futures::future::join_all;
     use nix::unistd::Gid;
     use tempfile::NamedTempFile;
     use url::Url;
@@ -745,33 +743,13 @@ mod test {
     use crate::task::Output;
     use crate::task::output::Type;
 
-    async fn redirect_stdio(
-        mut event_rx: broadcast::Receiver<Event>,
-        image_pull_fails: Arc<AtomicUsize>,
-    ) -> anyhow::Result<()> {
-        while let Ok(event) = event_rx.recv().await {
-            match event {
-                Event::TaskStdout { message, .. } => {
-                    std::io::stdout()
-                        .write_all(&message)
-                        .context("failed to write stdout")?;
-                }
-                Event::TaskStderr { message, .. } => {
-                    std::io::stderr()
-                        .write_all(&message)
-                        .context("failed to write stderr")?;
-                }
-                Event::TaskFailed { message, .. } => {
-                    eprintln!("{message}");
-                }
-                Event::ImagePullFailed { .. } => {
-                    image_pull_fails.fetch_add(1, Ordering::Relaxed);
-                }
-                _ => {}
-            }
+    async fn events(mut rx: broadcast::Receiver<Event>) -> Vec<Event> {
+        let mut events = Vec::new();
+        while let Ok(event) = rx.recv().await {
+            events.push(event);
         }
 
-        Ok(())
+        events
     }
 
     async fn create_backend(config: Config) -> Result<Backend> {
@@ -796,10 +774,6 @@ mod test {
             .context("failed to create temporary file")?
             .into_temp_path();
 
-        let image_pull_fails = Arc::new(AtomicUsize::new(0));
-        let (event_tx, event_rx) = broadcast::channel(1024);
-        tokio::task::spawn(redirect_stdio(event_rx, image_pull_fails.clone()));
-
         // Run the task
         let results = backend
             .run(
@@ -823,7 +797,7 @@ mod test {
                             .build(),
                     ])
                     .build(),
-                Some(event_tx),
+                None,
                 CancellationToken::new(),
             )
             .context("failed to run task")?
@@ -838,6 +812,7 @@ mod test {
             stdout.contains(&gid.to_string()),
             "task stdout of `{stdout}` did not contain the expected output"
         );
+
         Ok(())
     }
 
@@ -849,9 +824,8 @@ mod test {
             .context("failed to create temporary file")?
             .into_temp_path();
 
-        let image_pull_fails = Arc::new(AtomicUsize::new(0));
-        let (event_tx, event_rx) = broadcast::channel(1024);
-        tokio::task::spawn(redirect_stdio(event_rx, image_pull_fails.clone()));
+        let (events_tx, events_rx) = broadcast::channel(1024);
+        let events = tokio::task::spawn(events(events_rx));
 
         let results = backend
             .run(
@@ -882,21 +856,152 @@ mod test {
                             .build(),
                     ])
                     .build(),
-                Some(event_tx),
+                Some(events_tx),
                 CancellationToken::new(),
             )
             .context("failed to run task")?
             .await
             .context("task execution failed")?;
 
+        let events = events.await.unwrap();
+
         assert!(results.first().status.success(), "container failed");
-        assert_eq!(image_pull_fails.load(Ordering::Relaxed), 2);
+        assert_eq!(
+            events
+                .iter()
+                .filter(|e| matches!(e, Event::ImagePullFailed { .. }))
+                .count(),
+            2
+        );
 
         // Assert that the command was run
         let stdout = fs::read_to_string(&stdout_path).context("failed to read stdout file")?;
         assert!(
             stdout.contains("Hello, world!"),
             "task stdout of `{stdout}` did not contain the expected output"
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn concurrent_task_events() -> anyhow::Result<()> {
+        let backend = Arc::new(create_backend(Config::default()).await?);
+
+        let (events1_tx, events1_rx) = broadcast::channel(1024);
+        let events1 = tokio::task::spawn(events(events1_rx));
+
+        let (events2_tx, events2_rx) = broadcast::channel(1024);
+        let events2 = tokio::task::spawn(events(events2_rx));
+
+        // Spawn the first task
+        let backend1 = backend.clone();
+        let task1 = tokio::spawn(async move {
+            backend1
+                .run(
+                    Task::builder()
+                        .executions(NonEmpty::new(
+                            Execution::builder()
+                                .images(["ubuntu:latest"])?
+                                .program("/bin/sh")
+                                .args([String::from("-c"), String::from("echo task1")])
+                                .build(),
+                        ))
+                        .build(),
+                    Some(events1_tx),
+                    CancellationToken::new(),
+                )
+                .expect("failed to run task")
+                .await?;
+
+            anyhow::Ok(())
+        });
+
+        // Spawn the second task
+        let task2 = tokio::spawn(async move {
+            backend
+                .run(
+                    Task::builder()
+                        .executions(NonEmpty::new(
+                            Execution::builder()
+                                .images(["ubuntu:latest"])?
+                                .program("/bin/sh")
+                                .args([String::from("-c"), String::from("echo task2")])
+                                .build(),
+                        ))
+                        .build(),
+                    Some(events2_tx),
+                    CancellationToken::new(),
+                )
+                .expect("failed to run task")
+                .await?;
+
+            anyhow::Ok(())
+        });
+
+        // Wait for the tasks to complete and check for errors
+        for result in join_all([task1, task2]).await {
+            result
+                .context("failed to join task")?
+                .context("task failed")?;
+        }
+
+        let events1 = events1
+            .await
+            .context("failed to wait for the first task's events")?;
+        let events2 = events2
+            .await
+            .context("failed to wait for the first task's events")?;
+
+        // Ensure there is one started event per events list
+        assert_eq!(
+            events1
+                .iter()
+                .filter(|e| matches!(e, Event::TaskStarted { .. }))
+                .count(),
+            1
+        );
+
+        assert_eq!(
+            events2
+                .iter()
+                .filter(|e| matches!(e, Event::TaskStarted { .. }))
+                .count(),
+            1
+        );
+
+        // Ensure there is one completed event per events list
+        assert_eq!(
+            events1
+                .iter()
+                .filter(|e| matches!(e, Event::TaskCompleted { .. }))
+                .count(),
+            1
+        );
+
+        assert_eq!(
+            events2
+                .iter()
+                .filter(|e| matches!(e, Event::TaskCompleted { .. }))
+                .count(),
+            1
+        );
+
+        // Ensure there is one a stdout event per events list
+        assert_eq!(
+            events1
+                .iter()
+                .filter(|e| matches!(e, Event::TaskStdout { message, .. } if message.as_ref() == b"task1\n"))
+                .count(),
+            1
+        );
+
+        assert_eq!(
+            events2
+                .iter()
+                .filter(|e| matches!(e, Event::TaskStdout { message, .. } if message.as_ref() == b"task2\n"))
+                .count(),
+            1
         );
 
         Ok(())

--- a/crankshaft-engine/src/service/runner/backend/docker.rs
+++ b/crankshaft-engine/src/service/runner/backend/docker.rs
@@ -728,6 +728,7 @@ fn add_shared_mounts(volumes: Vec<String>, tempdir: &Path, mounts: &mut Vec<Moun
 #[cfg(test)]
 #[cfg(target_os = "linux")]
 mod test {
+    use std::assert_matches;
     use std::fs;
 
     use anyhow::Context;
@@ -886,6 +887,38 @@ mod test {
 
     #[tokio::test]
     async fn concurrent_task_events() -> anyhow::Result<()> {
+        fn assert_events(events: &[Event], stdout: &[u8]) -> TaskId {
+            // There should be six or eight events generated
+            // Eight events indicates the image was pulled
+            assert!(events.len() == 6 || events.len() == 8);
+
+            // The first event should be the created event; extract the id
+            let task_id = match &events[0] {
+                Event::TaskCreated { id, .. } => *id,
+                _ => panic!("the first event should be the created event"),
+            };
+
+            if events.len() == 6 {
+                assert_matches!(&events[1], Event::TaskContainerCreated { id, .. } if *id == task_id);
+                assert_matches!(&events[2], Event::TaskStarted { id } if *id == task_id);
+                assert_matches!(&events[3], Event::TaskStdout { id, message } if *id == task_id && message == stdout);
+                assert_matches!(&events[4], Event::TaskContainerExited { id, exit_status, .. } if *id == task_id && exit_status.success());
+                assert_matches!(&events[5], Event::TaskCompleted { id, exit_statuses } if *id == task_id && exit_statuses[0].success());
+            } else if events.len() == 8 {
+                assert_matches!(&events[1], Event::ImagePullStarted { id, name } if *id == task_id && name == "ubuntu:latest");
+                assert_matches!(&events[2], Event::ImagePullFinished { id, name } if *id == task_id && name == "ubuntu:latest");
+                assert_matches!(&events[3], Event::TaskContainerCreated { id, .. } if *id == task_id);
+                assert_matches!(&events[4], Event::TaskStarted { id } if *id == task_id);
+                assert_matches!(&events[5], Event::TaskStdout { id, message } if *id == task_id && message == stdout);
+                assert_matches!(&events[6], Event::TaskContainerExited { id, exit_status, .. } if *id == task_id && exit_status.success());
+                assert_matches!(&events[7], Event::TaskCompleted { id, exit_statuses } if *id == task_id && exit_statuses[0].success());
+            } else {
+                panic!("unexpected number of events");
+            }
+
+            task_id
+        }
+
         let backend = Arc::new(create_backend(Config::default()).await?);
 
         let (events1_tx, events1_rx) = broadcast::channel(1024);
@@ -953,56 +986,9 @@ mod test {
             .await
             .context("failed to wait for the first task's events")?;
 
-        // Ensure there is one started event per events list
-        assert_eq!(
-            events1
-                .iter()
-                .filter(|e| matches!(e, Event::TaskStarted { .. }))
-                .count(),
-            1
-        );
-
-        assert_eq!(
-            events2
-                .iter()
-                .filter(|e| matches!(e, Event::TaskStarted { .. }))
-                .count(),
-            1
-        );
-
-        // Ensure there is one completed event per events list
-        assert_eq!(
-            events1
-                .iter()
-                .filter(|e| matches!(e, Event::TaskCompleted { .. }))
-                .count(),
-            1
-        );
-
-        assert_eq!(
-            events2
-                .iter()
-                .filter(|e| matches!(e, Event::TaskCompleted { .. }))
-                .count(),
-            1
-        );
-
-        // Ensure there is one a stdout event per events list
-        assert_eq!(
-            events1
-                .iter()
-                .filter(|e| matches!(e, Event::TaskStdout { message, .. } if message.as_ref() == b"task1\n"))
-                .count(),
-            1
-        );
-
-        assert_eq!(
-            events2
-                .iter()
-                .filter(|e| matches!(e, Event::TaskStdout { message, .. } if message.as_ref() == b"task2\n"))
-                .count(),
-            1
-        );
+        let task_id1 = assert_events(&events1, b"task1\n");
+        let task_id2 = assert_events(&events2, b"task2\n");
+        assert!(task_id1 != task_id2, "expected different task identifiers");
 
         Ok(())
     }

--- a/crankshaft-engine/src/service/runner/backend/docker.rs
+++ b/crankshaft-engine/src/service/runner/backend/docker.rs
@@ -150,8 +150,6 @@ pub struct Backend {
     config: Config,
     /// The available resources reported by Docker.
     resources: Resources,
-    /// The events sender for the backend.
-    events: Option<broadcast::Sender<Event>>,
     /// The unique name generator for tasks without names.
     names: Arc<Mutex<GeneratorIterator<UniqueAlphanumeric>>>,
 }
@@ -165,7 +163,6 @@ impl Backend {
     pub async fn initialize_default_with(
         config: Config,
         names: Arc<Mutex<GeneratorIterator<UniqueAlphanumeric>>>,
-        events: Option<broadcast::Sender<Event>>,
     ) -> Result<Self> {
         let client =
             Docker::with_defaults().context("failed to connect to the local Docker daemon")?;
@@ -316,7 +313,6 @@ impl Backend {
             client,
             config,
             resources,
-            events,
             names,
         })
     }
@@ -328,9 +324,8 @@ impl Backend {
     /// when attempting to connect to the Docker daemon.
     pub async fn initialize_default(
         names: Arc<Mutex<GeneratorIterator<UniqueAlphanumeric>>>,
-        events: Option<broadcast::Sender<Event>>,
     ) -> Result<Self> {
-        Self::initialize_default_with(Config::default(), names, events).await
+        Self::initialize_default_with(Config::default(), names).await
     }
 
     /// Gets a reference to the inner Docker client.
@@ -341,11 +336,6 @@ impl Backend {
     /// Gets information about the resources available to the Docker backend.
     pub fn resources(&self) -> &Resources {
         &self.resources
-    }
-
-    /// Gets the events sender for the backend, if there is one.
-    pub fn events(&self) -> Option<broadcast::Sender<Event>> {
-        self.events.clone()
     }
 }
 
@@ -422,6 +412,7 @@ impl crate::Backend for Backend {
     fn run(
         &self,
         task: Task,
+        events: Option<broadcast::Sender<Event>>,
         token: CancellationToken,
     ) -> Result<BoxFuture<'static, Result<NonEmpty<ExecutionResult>, TaskRunError>>> {
         let task_id = next_task_id();
@@ -429,7 +420,6 @@ impl crate::Backend for Backend {
         let run_cleanup = self.config.cleanup();
         let events_config = self.config.events();
         let use_service = self.resources.use_service();
-        let events = self.events.clone();
         let names = self.names.clone();
 
         let task_token = CancellationToken::new();
@@ -736,103 +726,68 @@ fn add_shared_mounts(volumes: Vec<String>, tempdir: &Path, mounts: &mut Vec<Moun
 }
 
 #[cfg(test)]
+#[cfg(target_os = "linux")]
 mod test {
     use std::fs;
     use std::io::Write;
-    use std::ops::Deref;
     use std::sync::atomic::AtomicUsize;
     use std::sync::atomic::Ordering;
 
     use anyhow::Context;
+    use nix::unistd::Gid;
     use tempfile::NamedTempFile;
     use url::Url;
 
     use super::*;
-    use crate::service::runner::Backend;
+    use crate::service::runner::Backend as _;
     use crate::service::runner::NAME_BUFFER_LEN;
+    use crate::task::Execution;
     use crate::task::Output;
     use crate::task::output::Type;
 
-    struct BackendTest {
-        backend: super::Backend,
+    async fn redirect_stdio(
+        mut event_rx: broadcast::Receiver<Event>,
         image_pull_fails: Arc<AtomicUsize>,
-    }
-
-    impl BackendTest {
-        async fn redirect_stdio(
-            mut event_rx: broadcast::Receiver<Event>,
-            image_pull_fails: Arc<AtomicUsize>,
-        ) -> anyhow::Result<()> {
-            while let Ok(event) = event_rx.recv().await {
-                match event {
-                    Event::TaskStdout { message, .. } => {
-                        std::io::stdout()
-                            .write_all(&message)
-                            .context("failed to write stdout")?;
-                    }
-                    Event::TaskStderr { message, .. } => {
-                        std::io::stderr()
-                            .write_all(&message)
-                            .context("failed to write stderr")?;
-                    }
-                    Event::TaskFailed { message, .. } => {
-                        eprintln!("{message}");
-                    }
-                    Event::ImagePullFailed { .. } => {
-                        image_pull_fails.fetch_add(1, Ordering::Relaxed);
-                    }
-                    _ => {}
+    ) -> anyhow::Result<()> {
+        while let Ok(event) = event_rx.recv().await {
+            match event {
+                Event::TaskStdout { message, .. } => {
+                    std::io::stdout()
+                        .write_all(&message)
+                        .context("failed to write stdout")?;
                 }
+                Event::TaskStderr { message, .. } => {
+                    std::io::stderr()
+                        .write_all(&message)
+                        .context("failed to write stderr")?;
+                }
+                Event::TaskFailed { message, .. } => {
+                    eprintln!("{message}");
+                }
+                Event::ImagePullFailed { .. } => {
+                    image_pull_fails.fetch_add(1, Ordering::Relaxed);
+                }
+                _ => {}
             }
-
-            Ok(())
         }
 
-        async fn new(config: Config) -> anyhow::Result<Self> {
-            let names = Arc::new(Mutex::new(GeneratorIterator::new(
-                UniqueAlphanumeric::default_with_expected_generations(NAME_BUFFER_LEN),
-                NAME_BUFFER_LEN,
-            )));
-
-            let image_pull_fails = Arc::new(AtomicUsize::new(0));
-            let (event_tx, event_rx) = broadcast::channel(1024);
-            tokio::task::spawn(Self::redirect_stdio(event_rx, image_pull_fails.clone()));
-
-            let backend = super::Backend::initialize_default_with(config, names, Some(event_tx))
-                .await
-                .context("failed to create backend")?;
-
-            Ok(Self {
-                backend,
-                image_pull_fails,
-            })
-        }
+        Ok(())
     }
 
-    impl Deref for BackendTest {
-        type Target = super::Backend;
+    async fn create_backend(config: Config) -> Result<Backend> {
+        let names = Arc::new(Mutex::new(GeneratorIterator::new(
+            UniqueAlphanumeric::default_with_expected_generations(NAME_BUFFER_LEN),
+            NAME_BUFFER_LEN,
+        )));
 
-        fn deref(&self) -> &Self::Target {
-            &self.backend
-        }
+        Backend::initialize_default_with(config, names)
+            .await
+            .context("failed to create backend")
     }
 
     #[tokio::test]
-    #[cfg(target_os = "linux")]
     async fn backend_adds_user_egid() -> anyhow::Result<()> {
-        use std::fs;
-
-        use anyhow::Context;
-        use nix::unistd::Gid;
-        use tempfile::NamedTempFile;
-        use url::Url;
-
-        use super::*;
-        use crate::service::runner::Backend as _;
-        use crate::task::Execution;
-        use crate::task::Output;
-
-        let backend = BackendTest::new(Config::default()).await?;
+        let backend = create_backend(Config::default()).await?;
 
         // Get the current user's effective gid
         let gid = Gid::effective();
@@ -840,6 +795,10 @@ mod test {
         let stdout_path = NamedTempFile::new()
             .context("failed to create temporary file")?
             .into_temp_path();
+
+        let image_pull_fails = Arc::new(AtomicUsize::new(0));
+        let (event_tx, event_rx) = broadcast::channel(1024);
+        tokio::task::spawn(redirect_stdio(event_rx, image_pull_fails.clone()));
 
         // Run the task
         let results = backend
@@ -864,6 +823,7 @@ mod test {
                             .build(),
                     ])
                     .build(),
+                Some(event_tx),
                 CancellationToken::new(),
             )
             .context("failed to run task")?
@@ -882,13 +842,16 @@ mod test {
     }
 
     #[tokio::test]
-    #[cfg(target_os = "linux")]
     async fn backend_supports_fallback_images() -> anyhow::Result<()> {
-        let backend = BackendTest::new(Config::default()).await?;
+        let backend = create_backend(Config::default()).await?;
 
         let stdout_path = NamedTempFile::new()
             .context("failed to create temporary file")?
             .into_temp_path();
+
+        let image_pull_fails = Arc::new(AtomicUsize::new(0));
+        let (event_tx, event_rx) = broadcast::channel(1024);
+        tokio::task::spawn(redirect_stdio(event_rx, image_pull_fails.clone()));
 
         let results = backend
             .run(
@@ -919,6 +882,7 @@ mod test {
                             .build(),
                     ])
                     .build(),
+                Some(event_tx),
                 CancellationToken::new(),
             )
             .context("failed to run task")?
@@ -926,7 +890,7 @@ mod test {
             .context("task execution failed")?;
 
         assert!(results.first().status.success(), "container failed");
-        assert_eq!(backend.image_pull_fails.load(Ordering::Relaxed), 2);
+        assert_eq!(image_pull_fails.load(Ordering::Relaxed), 2);
 
         // Assert that the command was run
         let stdout = fs::read_to_string(&stdout_path).context("failed to read stdout file")?;

--- a/crankshaft-engine/src/service/runner/backend/generic.rs
+++ b/crankshaft-engine/src/service/runner/backend/generic.rs
@@ -45,8 +45,6 @@ pub struct Backend {
     config: Config,
     /// The execution defaults.
     defaults: Option<Defaults>,
-    /// The events sender for the backend.
-    events: Option<broadcast::Sender<Event>>,
     /// The unique name generator for tasks without names.
     names: Arc<Mutex<GeneratorIterator<UniqueAlphanumeric>>>,
 }
@@ -58,7 +56,6 @@ impl Backend {
         config: Config,
         defaults: Option<Defaults>,
         names: Arc<Mutex<GeneratorIterator<UniqueAlphanumeric>>>,
-        events: Option<broadcast::Sender<Event>>,
     ) -> Result<Self> {
         // TODO(clay): this could be "taken" instead to avoid the clone.
         let driver = Driver::initialize(config.driver().clone())
@@ -69,7 +66,6 @@ impl Backend {
             driver,
             config,
             defaults,
-            events,
             names,
         })
     }
@@ -116,6 +112,7 @@ impl crate::Backend for Backend {
     fn run(
         &self,
         task: Task,
+        events: Option<broadcast::Sender<Event>>,
         token: CancellationToken,
     ) -> Result<BoxFuture<'static, Result<NonEmpty<ExecutionResult>, TaskRunError>>> {
         let driver = self.driver.clone();
@@ -127,7 +124,6 @@ impl crate::Backend for Backend {
             .unwrap_or_default();
 
         let task_id = next_task_id();
-        let events = self.events.clone();
         let names = self.names.clone();
 
         let task_token = CancellationToken::new();

--- a/crankshaft-engine/src/service/runner/backend/tes.rs
+++ b/crankshaft-engine/src/service/runner/backend/tes.rs
@@ -68,8 +68,6 @@ struct BackendState {
     policy: ExponentialFactorBackoff,
     /// The permits for ensuring a maximum number of concurrent server requests.
     permits: Semaphore,
-    /// The events sender for Crankshaft events.
-    events: Option<broadcast::Sender<Event>>,
 }
 
 impl BackendState {
@@ -114,7 +112,7 @@ impl Backend {
     /// )));
     ///
     /// # tokio_test::block_on(async {
-    /// let backend = Backend::initialize(config, names, None).await;
+    /// let backend = Backend::initialize(config, names).await;
     /// # });
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -122,7 +120,6 @@ impl Backend {
     pub async fn initialize(
         config: Config,
         names: Arc<Mutex<GeneratorIterator<UniqueAlphanumeric>>>,
-        events: Option<broadcast::Sender<Event>>,
     ) -> Self {
         let (url, http, interval) = config.into_parts();
         let mut builder = Client::builder().url(url);
@@ -143,7 +140,6 @@ impl Backend {
                 http.max_concurrency
                     .unwrap_or(DEFAULT_MAX_CONCURRENT_REQUESTS),
             ),
-            events,
         });
 
         // SAFETY: the name generator should _never_ run out of entries.
@@ -282,6 +278,7 @@ impl crate::Backend for Backend {
     fn run(
         &self,
         task: Task,
+        events: Option<broadcast::Sender<Event>>,
         token: CancellationToken,
     ) -> Result<BoxFuture<'static, Result<NonEmpty<ExecutionResult>, TaskRunError>>> {
         let task_id = next_task_id();
@@ -300,7 +297,7 @@ impl crate::Backend for Backend {
 
             // Add the task to the monitor
             let (completed_tx, completed_rx) = oneshot::channel();
-            let tag = monitor.add_task(task_id, task_name.clone(), completed_tx).await;
+            let tag = monitor.add_task(task_id, task_name.clone(), events.clone(), completed_tx).await;
 
             task.tags
                 .get_or_insert_default()
@@ -329,7 +326,7 @@ impl crate::Backend for Backend {
             let task_token = CancellationToken::new();
 
             send_event!(
-                state.events,
+                events,
                 Event::TaskCreated {
                     id: task_id,
                     name: task_name.clone(),
@@ -377,7 +374,7 @@ impl crate::Backend for Backend {
             // Send an event for the result
             match &result {
                 Ok(results) => send_event!(
-                    state.events,
+                    events,
                     Event::TaskCompleted {
                         id: task_id,
                         // SAFETY: NonEmpty -> NonEmpty
@@ -385,13 +382,13 @@ impl crate::Backend for Backend {
                     }
                 ),
                 Err(TaskRunError::Canceled) => {
-                    send_event!(state.events, Event::TaskCanceled { id: task_id })
+                    send_event!(events, Event::TaskCanceled { id: task_id })
                 }
                 Err(TaskRunError::Preempted) => {
-                    send_event!(state.events, Event::TaskPreempted { id: task_id })
+                    send_event!(events, Event::TaskPreempted { id: task_id })
                 }
                 Err(TaskRunError::Other(e)) => send_event!(
-                    state.events,
+                    events,
                     Event::TaskFailed {
                         id: task_id,
                         message: format!("{e:#}")

--- a/crankshaft-engine/src/service/runner/backend/tes.rs
+++ b/crankshaft-engine/src/service/runner/backend/tes.rs
@@ -35,6 +35,7 @@ use tokio::sync::Semaphore;
 use tokio::sync::broadcast;
 use tokio::sync::oneshot;
 use tokio_util::sync::CancellationToken;
+use tracing::error;
 use tracing::info;
 
 use super::TaskRunError;
@@ -297,103 +298,117 @@ impl crate::Backend for Backend {
 
             // Add the task to the monitor
             let (completed_tx, completed_rx) = oneshot::channel();
-            let tag = monitor.add_task(task_id, task_name.clone(), events.clone(), completed_tx).await;
+            let tag = monitor
+                .add_task(task_id, task_name.clone(), events.clone(), completed_tx)
+                .await;
 
-            task.tags
-                .get_or_insert_default()
-                .insert(monitor::CRANKSHAFT_GROUP_TAG_NAME.to_string(), tag);
+            // Create the TES task and wait for it to complete
+            let mut tes_id = None;
+            let result = async {
+                task.tags
+                    .get_or_insert_default()
+                    .insert(monitor::CRANKSHAFT_GROUP_TAG_NAME.to_string(), tag);
 
-            let permit = state
-                .permits
-                .acquire()
-                .await
-                .context("failed to acquire network request permit")?;
-
-            let tes_id = select! {
-                // Always poll the cancellation token first
-                biased;
-                _ = token.cancelled() => {
-                    return Err(TaskRunError::Canceled);
-                }
-                res = state.client.create_task(&task, state.policy()) => {
-                    res.context("failed to create task with TES server")?.id
-                }
-            };
-
-            // Drop the permit now that the request has completed
-            drop(permit);
-
-            let task_token = CancellationToken::new();
-
-            send_event!(
-                events,
-                Event::TaskCreated {
-                    id: task_id,
-                    name: task_name.clone(),
-                    tes_id: Some(tes_id.clone()),
-                    token: task_token.clone()
-                }
-            );
-
-            let result = select! {
-                // Always poll the cancellation token first
-                biased;
-                _ = task_token.cancelled() =>{
-                    Err(TaskRunError::Canceled)
-                }
-                _ = token.cancelled() => {
-                    Err(TaskRunError::Canceled)
-                }
-                res = Self::wait_task(&state, &monitor, task_id, &task_name, &tes_id, completed_rx) => {
-                    res
-                }
-            };
-
-            if let Err(TaskRunError::Canceled) = &result {
                 let permit = state
                     .permits
                     .acquire()
                     .await
-                    .context("failed to acquire permit")?;
+                    .context("failed to acquire network request permit")?;
 
-                info!("canceling TES task `{tes_id}` (task `{task_name}`)");
-
-                // Cancel the task
-                state
-                    .client
-                    .cancel_task(&tes_id, state.policy())
-                    .await
-                    .context("failed to cancel task with TES server")?;
+                let id = select! {
+                    // Always poll the cancellation token first
+                    biased;
+                    _ = token.cancelled() => {
+                        return Err(TaskRunError::Canceled);
+                    }
+                    res = state.client.create_task(&task, state.policy()) => {
+                        res.context("failed to create task with TES server")?.id
+                    }
+                };
 
                 // Drop the permit now that the request has completed
                 drop(permit);
+
+                tes_id = Some(id);
+
+                let task_token = CancellationToken::new();
+
+                send_event!(
+                    events,
+                    Event::TaskCreated {
+                        id: task_id,
+                        name: task_name.clone(),
+                        tes_id: tes_id.clone(),
+                        token: task_token.clone()
+                    }
+                );
+
+                select! {
+                    // Always poll the cancellation token first
+                    biased;
+                    _ = task_token.cancelled() =>{
+                        Err(TaskRunError::Canceled)
+                    }
+                    _ = token.cancelled() => {
+                        Err(TaskRunError::Canceled)
+                    }
+                    res = Self::wait_task(&state, &monitor, task_id, &task_name, tes_id.as_deref().unwrap(), completed_rx) => {
+                        res
+                    }
+                }
+            }
+            .await;
+
+            // Remove the task from the monitor
+            monitor.remove_task(task_id).await;
+
+            // Cancel the TES task if the task was canceled
+            // At this point, log errors instead of returning a different one
+            if let (Some(tes_id), Err(TaskRunError::Canceled)) = (&tes_id, &result) {
+                match state.permits.acquire().await {
+                    Ok(permit) => {
+                        info!("canceling TES task `{tes_id}` (task `{task_name}`)");
+
+                        // Cancel the task
+                        if let Err(e) = state.client.cancel_task(&tes_id, state.policy()).await {
+                            error!("failed to cancel task with TES server: {e:#}");
+                        }
+
+                        // Drop the permit now that the request has completed
+                        drop(permit);
+                    }
+                    Err(e) => {
+                        error!("failed to acquire permit to cancel TES task: {e}");
+                    }
+                }
             }
 
-            monitor.remove_task(&tes_id).await;
-
-            // Send an event for the result
-            match &result {
-                Ok(results) => send_event!(
-                    events,
-                    Event::TaskCompleted {
-                        id: task_id,
-                        // SAFETY: NonEmpty -> NonEmpty
-                        exit_statuses: NonEmpty::collect(results.iter().map(|r| r.status)).unwrap(),
+            // If the TES task was created, send a corresponding completion event
+            if tes_id.is_some() {
+                match &result {
+                    Ok(results) => send_event!(
+                        events,
+                        Event::TaskCompleted {
+                            id: task_id,
+                            // SAFETY: NonEmpty -> NonEmpty
+                            exit_statuses: NonEmpty::collect(results.iter().map(|r| r.status))
+                                .unwrap(),
+                        }
+                    ),
+                    Err(TaskRunError::Canceled) => {
+                        send_event!(events, Event::TaskCanceled { id: task_id })
                     }
-                ),
-                Err(TaskRunError::Canceled) => {
-                    send_event!(events, Event::TaskCanceled { id: task_id })
-                }
-                Err(TaskRunError::Preempted) => {
-                    send_event!(events, Event::TaskPreempted { id: task_id })
-                }
-                Err(TaskRunError::Other(e)) => send_event!(
-                    events,
-                    Event::TaskFailed {
-                        id: task_id,
-                        message: format!("{e:#}")
+                    Err(TaskRunError::Preempted) => {
+                        send_event!(events, Event::TaskPreempted { id: task_id })
                     }
-                ),
+                    Err(TaskRunError::Other(e)) => send_event!(
+                        events,
+                        Event::TaskFailed {
+                            id: task_id,
+                            message: format!("{e:#}")
+                        }
+                    ),
+                }
             }
 
             result

--- a/crankshaft-engine/src/service/runner/backend/tes/monitor.rs
+++ b/crankshaft-engine/src/service/runner/backend/tes/monitor.rs
@@ -18,6 +18,7 @@ use tes::v1::types::requests::View;
 use tes::v1::types::responses::ListTasks;
 use tes::v1::types::task::State as TesState;
 use tokio::select;
+use tokio::sync::broadcast;
 use tokio::sync::oneshot;
 use tokio::time::MissedTickBehavior;
 use tracing::debug;
@@ -31,6 +32,8 @@ pub const CRANKSHAFT_GROUP_TAG_NAME: &str = "crankshaft-task-group";
 struct Task {
     /// The name of the task.
     name: String,
+    /// The events sender for the task.
+    events: Option<broadcast::Sender<Event>>,
     /// The sender for the "completed" notification.
     completed: oneshot::Sender<Result<()>>,
 }
@@ -96,6 +99,7 @@ impl TaskMonitor {
         &self,
         id: TaskId,
         name: String,
+        events: Option<broadcast::Sender<Event>>,
         completed: oneshot::Sender<Result<()>>,
     ) -> String {
         let mut state = self.state.lock().expect("failed to lock TES monitor state");
@@ -113,7 +117,14 @@ impl TaskMonitor {
             );
         }
 
-        state.tasks.insert(id, Task { name, completed });
+        state.tasks.insert(
+            id,
+            Task {
+                name,
+                events,
+                completed,
+            },
+        );
 
         state.tag.clone()
     }
@@ -209,15 +220,14 @@ impl TaskMonitor {
                                 // The task is now running, send the started event
                                 if let Some(id) = state.ids.get(&task.id).copied()
                                     && state.running.insert(id)
+                                    && let Some(Task { name, events, .. }) = state.tasks.get(&id)
                                 {
-                                    if let Some(Task { name, .. }) = state.tasks.get(&id) {
-                                        info!(
-                                            "TES task `{tes_id}` (task `{name}`) is now running",
-                                            tes_id = task.id
-                                        );
-                                    }
+                                    info!(
+                                        "TES task `{tes_id}` (task `{name}`) is now running",
+                                        tes_id = task.id
+                                    );
 
-                                    send_event!(backend_state.events, Event::TaskStarted { id });
+                                    send_event!(events, Event::TaskStarted { id });
                                 }
                             }
                             TesState::Complete

--- a/crankshaft-engine/src/service/runner/backend/tes/monitor.rs
+++ b/crankshaft-engine/src/service/runner/backend/tes/monitor.rs
@@ -32,6 +32,10 @@ pub const CRANKSHAFT_GROUP_TAG_NAME: &str = "crankshaft-task-group";
 struct Task {
     /// The name of the task.
     name: String,
+    /// The TES id of the task.
+    ///
+    /// This is `None` until the task is created on the TES server.
+    tes_id: Option<String>,
     /// The events sender for the task.
     events: Option<broadcast::Sender<Event>>,
     /// The sender for the "completed" notification.
@@ -122,10 +126,10 @@ impl TaskMonitor {
             Task {
                 name,
                 events,
+                tes_id: None,
                 completed,
             },
         );
-
         state.tag.clone()
     }
 
@@ -134,16 +138,22 @@ impl TaskMonitor {
     /// This is called after the TES task has been created.
     pub async fn associate_task_id(&self, id: TaskId, tes_id: String) {
         let mut state = self.state.lock().expect("failed to lock TES monitor state");
-        state.ids.insert(tes_id, id);
+        if let Some(task) = state.tasks.get_mut(&id) {
+            task.tes_id = Some(tes_id.clone());
+            state.ids.insert(tes_id, id);
+        }
     }
 
     /// Removes a task from the monitor.
-    pub async fn remove_task(&self, tes_id: &str) {
+    pub async fn remove_task(&self, id: u64) {
         let mut state = self.state.lock().expect("failed to lock TES monitor state");
-        if let Some(id) = state.ids.get(tes_id).copied() {
-            state.tasks.remove(&id);
-            state.running.remove(&id);
+        if let Some(task) = state.tasks.remove(&id)
+            && let Some(tes_id) = task.tes_id
+        {
+            state.ids.remove(&tes_id);
         }
+
+        state.running.remove(&id);
     }
 
     /// Updates the tasks by querying the TES server for the current task state.


### PR DESCRIPTION
This PR moves the events channel used for sending Crankshaft events from the backend's initialization to the request to run a task.

This allows for a backend to be shared in environments where groups of tasks are associated with different event channels.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
