### PR TITLE
feat: task resource usage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ base64 = "0.22"
 bollard = "0.19.2"
 bon = "3.7.1"
 bytes = "1.10.1"
+chrono = "0.4"
 clap = { version = "4.5.45", features = ["derive"] }
 clap-verbosity-flag = "3.0.4"
 color-eyre = { version = "0.6", features = ["issue-url"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ ratatui = { version = "0.29.0", default-features = false, features = [
 ] }
 regex = "1.11.1"
 serde = { version = "1.0.219", features = ["derive"] }
+serde_json = "1.0"
 serde_yaml = "0.9"
 shlex = "1.3.0"
 ssh2 = "0.9.5"

--- a/crankshaft-config/CHANGELOG.md
+++ b/crankshaft-config/CHANGELOG.md
@@ -13,6 +13,14 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 * Added the `resource-usage-interval` option to the Docker backend
   configuration, which enables sampling a running container's resource usage
   at the given interval in seconds ([#XX](https://github.com/stjude-rust-labs/crankshaft/pull/XX)).
+* Added the `resource-usage-metadata` option to the TES backend
+  configuration, which enables reading task resource usage from the
+  documented `TaskLog.metadata` keys ([#XX](https://github.com/stjude-rust-labs/crankshaft/pull/XX)).
+
+#### Changed
+
+* `tes::Config::into_parts` now also returns the `resource-usage-metadata`
+  flag ([#XX](https://github.com/stjude-rust-labs/crankshaft/pull/XX)).
 
 ## 0.6.0 - 11-24-2025
 

--- a/crankshaft-config/CHANGELOG.md
+++ b/crankshaft-config/CHANGELOG.md
@@ -8,7 +8,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
-#### Added
+### Added
 
 * Added the `resource-usage-interval` option to the Docker backend
   configuration, which enables sampling a running container's resource usage
@@ -17,7 +17,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   configuration, which enables reading task resource usage from the
   documented `TaskLog.metadata` keys ([#86](https://github.com/stjude-rust-labs/crankshaft/pull/86)).
 
-#### Changed
+### Changed
 
 * `tes::Config::into_parts` now also returns the `resource-usage-metadata`
   flag ([#86](https://github.com/stjude-rust-labs/crankshaft/pull/86)).

--- a/crankshaft-config/CHANGELOG.md
+++ b/crankshaft-config/CHANGELOG.md
@@ -8,6 +8,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+#### Added
+
+* Added the `resource-usage-interval` option to the Docker backend
+  configuration, which enables sampling a running container's resource usage
+  at the given interval in seconds ([#XX](https://github.com/stjude-rust-labs/crankshaft/pull/XX)).
+
 ## 0.6.0 - 11-24-2025
 
 ### Added

--- a/crankshaft-config/CHANGELOG.md
+++ b/crankshaft-config/CHANGELOG.md
@@ -12,15 +12,15 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 * Added the `resource-usage-interval` option to the Docker backend
   configuration, which enables sampling a running container's resource usage
-  at the given interval in seconds ([#XX](https://github.com/stjude-rust-labs/crankshaft/pull/XX)).
+  at the given interval in seconds ([#86](https://github.com/stjude-rust-labs/crankshaft/pull/86)).
 * Added the `resource-usage-metadata` option to the TES backend
   configuration, which enables reading task resource usage from the
-  documented `TaskLog.metadata` keys ([#XX](https://github.com/stjude-rust-labs/crankshaft/pull/XX)).
+  documented `TaskLog.metadata` keys ([#86](https://github.com/stjude-rust-labs/crankshaft/pull/86)).
 
 #### Changed
 
 * `tes::Config::into_parts` now also returns the `resource-usage-metadata`
-  flag ([#XX](https://github.com/stjude-rust-labs/crankshaft/pull/XX)).
+  flag ([#86](https://github.com/stjude-rust-labs/crankshaft/pull/86)).
 
 ## 0.6.0 - 11-24-2025
 

--- a/crankshaft-config/src/backend/docker.rs
+++ b/crankshaft-config/src/backend/docker.rs
@@ -48,10 +48,12 @@ pub struct Config {
     /// The interval, in seconds, at which to sample a running container's
     /// resource usage and emit task resource usage events.
     ///
-    /// When unset, resource usage is not sampled and no resource usage events
-    /// are emitted.
+    /// When unset or zero, resource usage is not sampled and no resource
+    /// usage events are emitted.
+    ///
+    /// Sampling applies only to local container execution; it is not
+    /// supported for Docker Swarm services.
     #[serde(default)]
-    #[builder(into)]
     resource_usage_interval: Option<u64>,
 }
 

--- a/crankshaft-config/src/backend/docker.rs
+++ b/crankshaft-config/src/backend/docker.rs
@@ -45,6 +45,14 @@ pub struct Config {
     #[serde(default)]
     #[builder(default)]
     events: EventConfig,
+    /// The interval, in seconds, at which to sample a running container's
+    /// resource usage and emit task resource usage events.
+    ///
+    /// When unset, resource usage is not sampled and no resource usage events
+    /// are emitted.
+    #[serde(default)]
+    #[builder(into)]
+    resource_usage_interval: Option<u64>,
 }
 
 impl Config {
@@ -53,6 +61,14 @@ impl Config {
     /// failure).
     pub fn cleanup(&self) -> bool {
         self.cleanup
+    }
+
+    /// Gets the interval, in seconds, at which to sample a running
+    /// container's resource usage.
+    ///
+    /// Returns `None` when resource usage sampling is disabled.
+    pub fn resource_usage_interval(&self) -> Option<u64> {
+        self.resource_usage_interval
     }
 
     /// Gets the event configuration for the backend.

--- a/crankshaft-config/src/backend/tes.rs
+++ b/crankshaft-config/src/backend/tes.rs
@@ -32,8 +32,8 @@ pub struct Config {
     /// `MINIMAL`, which omits logs) and the following metadata keys, when
     /// present, are reported as task resource usage events:
     ///
-    /// * `peak_rss_bytes` — maximum resident memory, in bytes
-    /// * `avg_rss_bytes` — average resident memory, in bytes
+    /// * `peak_memory_bytes` — peak sampled memory, in bytes
+    /// * `avg_memory_bytes` — average sampled memory, in bytes
     /// * `cpu_time_ms` — total CPU time, in milliseconds
     /// * `user_cpu_time_ms` — user-mode CPU time, in milliseconds
     /// * `system_cpu_time_ms` — system-mode CPU time, in milliseconds

--- a/crankshaft-config/src/backend/tes.rs
+++ b/crankshaft-config/src/backend/tes.rs
@@ -22,6 +22,30 @@ pub struct Config {
 
     /// The poll interval, in seconds, to use for querying TES task status.
     interval: Option<u64>,
+
+    /// Whether to read task resource usage from the TES server's task log
+    /// metadata.
+    ///
+    /// The TES specification does not standardize resource usage reporting,
+    /// but designates `TaskLog.metadata` for implementation-specific data.
+    /// When enabled, tasks are polled with the `BASIC` view (rather than
+    /// `MINIMAL`, which omits logs) and the following metadata keys, when
+    /// present, are reported as task resource usage events:
+    ///
+    /// * `peak_rss_bytes` — maximum resident memory, in bytes
+    /// * `avg_rss_bytes` — average resident memory, in bytes
+    /// * `cpu_time_ms` — total CPU time, in milliseconds
+    /// * `user_cpu_time_ms` — user-mode CPU time, in milliseconds
+    /// * `system_cpu_time_ms` — system-mode CPU time, in milliseconds
+    /// * `disk_used_bytes` — disk space used, in bytes
+    ///
+    /// Values may be JSON numbers or numeric strings. Servers that do not
+    /// populate these keys simply produce no resource usage events.
+    ///
+    /// Defaults to `false`.
+    #[serde(default)]
+    #[builder(default)]
+    resource_usage_metadata: bool,
 }
 
 impl Config {
@@ -40,9 +64,20 @@ impl Config {
         self.interval
     }
 
+    /// Gets whether task resource usage is read from the TES server's task
+    /// log metadata.
+    pub fn resource_usage_metadata(&self) -> bool {
+        self.resource_usage_metadata
+    }
+
     /// Consumes `self` and returns the constituent, owned parts of the
     /// configuration.
-    pub fn into_parts(self) -> (Url, http::Config, Option<u64>) {
-        (self.url, self.http, self.interval)
+    pub fn into_parts(self) -> (Url, http::Config, Option<u64>, bool) {
+        (
+            self.url,
+            self.http,
+            self.interval,
+            self.resource_usage_metadata,
+        )
     }
 }

--- a/crankshaft-config/src/backend/tes.rs
+++ b/crankshaft-config/src/backend/tes.rs
@@ -33,7 +33,8 @@ pub struct Config {
     /// present, are reported as task resource usage events:
     ///
     /// * `peak_memory_bytes` — peak sampled memory, in bytes
-    /// * `avg_memory_bytes` — average sampled memory, in bytes
+    /// * `avg_memory_bytes` — average sampled memory, in bytes; the averaging
+    ///   method is server-defined
     /// * `cpu_time_ms` — total CPU time, in milliseconds
     /// * `user_cpu_time_ms` — user-mode CPU time, in milliseconds
     /// * `system_cpu_time_ms` — system-mode CPU time, in milliseconds

--- a/crankshaft-console/CHANGELOG.md
+++ b/crankshaft-console/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Added
 
+* Added handling for the task resource usage event ([#XX](https://github.com/stjude-rust-labs/crankshaft/pull/XX)).
 * Added cancellation of tasks from the TUI ([#53](https://github.com/stjude-rust-labs/crankshaft/pull/53))
 * Added initial TUI and server sync ([#46](https://github.com/stjude-rust-labs/crankshaft/pull/46)).
 * Added initial implementation ([#43](https://github.com/stjude-rust-labs/crankshaft/pull/43)).

--- a/crankshaft-console/CHANGELOG.md
+++ b/crankshaft-console/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Added
 
-* Added handling for the task resource usage event ([#XX](https://github.com/stjude-rust-labs/crankshaft/pull/XX)).
+* Added handling for the task resource usage event ([#86](https://github.com/stjude-rust-labs/crankshaft/pull/86)).
 * Added cancellation of tasks from the TUI ([#53](https://github.com/stjude-rust-labs/crankshaft/pull/53))
 * Added initial TUI and server sync ([#46](https://github.com/stjude-rust-labs/crankshaft/pull/46)).
 * Added initial implementation ([#43](https://github.com/stjude-rust-labs/crankshaft/pull/43)).

--- a/crankshaft-console/src/state/task.rs
+++ b/crankshaft-console/src/state/task.rs
@@ -53,7 +53,14 @@ impl TuiTasksState {
         };
 
         if let Some(task) = self.tasks.get_mut(&id) {
-            task.events.push(event);
+            // Keep the latest resource usage separately so that periodic
+            // snapshots do not hide lifecycle events or regress the task's
+            // display state
+            if let Some(EventKind::ResourceUsage(usage)) = event.event_kind {
+                task.usage = Some(usage);
+            } else {
+                task.events.push(event);
+            }
         } else {
             // Insert the task if this is a creation event
             // Otherwise, we missed the creation event, ignore the task.
@@ -134,7 +141,12 @@ pub struct Task {
     /// This is `Some` only for tasks from the TES backend.
     tes_id: Option<String>,
     /// The events of the task.
+    ///
+    /// Resource usage events are kept separately in `usage` so that they do
+    /// not affect the task's display state.
     events: Vec<Event>,
+    /// The latest resource usage reported for the task.
+    usage: Option<TaskResourceUsageEvent>,
 }
 
 impl Task {
@@ -152,6 +164,7 @@ impl Task {
             name,
             tes_id,
             events: vec![event],
+            usage: None,
         })
     }
 
@@ -165,11 +178,14 @@ impl Task {
             _ => return None,
         };
 
+        let (events, usage) = split_usage(events.events);
+
         Some(Self {
             id,
             name,
             tes_id,
-            events: events.events,
+            events,
+            usage,
         })
     }
 
@@ -201,8 +217,10 @@ impl Task {
             | Some(EventKind::ContainerCreated(_))
             | Some(EventKind::ContainerExited(_))
             | Some(EventKind::Stdout(_))
-            | Some(EventKind::Stderr(_))
-            | Some(EventKind::ResourceUsage(_)) => "Running",
+            | Some(EventKind::Stderr(_)) => "Running",
+            // Resource usage events are stored separately and never appear
+            // in the event list
+            Some(EventKind::ResourceUsage(_)) => "Running",
             Some(EventKind::Completed(_)) => "Completed",
             Some(EventKind::Failed(_) | EventKind::ImagePullFailed(_)) => "Failed",
             Some(EventKind::Canceled(_)) => "Canceled",
@@ -274,11 +292,16 @@ impl Task {
             Some(EventKind::Preempted(_)) => {
                 format!("task `{name}` has been preempted", name = self.name)
             }
-            Some(EventKind::ResourceUsage(_)) => {
-                format!("task `{name}` reported resource usage", name = self.name)
-            }
+            // Resource usage events are stored separately and never appear
+            // in the event list
+            Some(EventKind::ResourceUsage(_)) => Default::default(),
             None => Default::default(),
         }
+    }
+
+    /// Gets the latest resource usage reported for the task, if any.
+    pub fn usage(&self) -> Option<&TaskResourceUsageEvent> {
+        self.usage.as_ref()
     }
 
     /// Gets the last event of the task.
@@ -291,4 +314,21 @@ impl Task {
             .last()
             .expect("there should always be at least one event")
     }
+}
+
+/// Splits resource usage events out of an event list, returning the remaining
+/// events and the latest resource usage, if any.
+fn split_usage(events: Vec<Event>) -> (Vec<Event>, Option<TaskResourceUsageEvent>) {
+    let mut usage = None;
+    let events = events
+        .into_iter()
+        .filter_map(|event| match event.event_kind {
+            Some(EventKind::ResourceUsage(u)) => {
+                usage = Some(u);
+                None
+            }
+            _ => Some(event),
+        })
+        .collect();
+    (events, usage)
 }

--- a/crankshaft-console/src/state/task.rs
+++ b/crankshaft-console/src/state/task.rs
@@ -14,6 +14,7 @@ use crankshaft_monitor::proto::TaskCreatedEvent;
 use crankshaft_monitor::proto::TaskEvents;
 use crankshaft_monitor::proto::TaskFailedEvent;
 use crankshaft_monitor::proto::TaskPreemptedEvent;
+use crankshaft_monitor::proto::TaskResourceUsageEvent;
 use crankshaft_monitor::proto::TaskStartedEvent;
 use crankshaft_monitor::proto::TaskStderrEvent;
 use crankshaft_monitor::proto::TaskStdoutEvent;
@@ -46,7 +47,8 @@ impl TuiTasksState {
             | Some(EventKind::Completed(TaskCompletedEvent { id, .. }))
             | Some(EventKind::Failed(TaskFailedEvent { id, .. }))
             | Some(EventKind::Canceled(TaskCanceledEvent { id, .. }))
-            | Some(EventKind::Preempted(TaskPreemptedEvent { id, .. })) => *id,
+            | Some(EventKind::Preempted(TaskPreemptedEvent { id, .. }))
+            | Some(EventKind::ResourceUsage(TaskResourceUsageEvent { id, .. })) => *id,
             None => return,
         };
 
@@ -199,7 +201,8 @@ impl Task {
             | Some(EventKind::ContainerCreated(_))
             | Some(EventKind::ContainerExited(_))
             | Some(EventKind::Stdout(_))
-            | Some(EventKind::Stderr(_)) => "Running",
+            | Some(EventKind::Stderr(_))
+            | Some(EventKind::ResourceUsage(_)) => "Running",
             Some(EventKind::Completed(_)) => "Completed",
             Some(EventKind::Failed(_) | EventKind::ImagePullFailed(_)) => "Failed",
             Some(EventKind::Canceled(_)) => "Canceled",
@@ -270,6 +273,9 @@ impl Task {
             }
             Some(EventKind::Preempted(_)) => {
                 format!("task `{name}` has been preempted", name = self.name)
+            }
+            Some(EventKind::ResourceUsage(_)) => {
+                format!("task `{name}` reported resource usage", name = self.name)
             }
             None => Default::default(),
         }

--- a/crankshaft-console/src/view/tasks.rs
+++ b/crankshaft-console/src/view/tasks.rs
@@ -1,4 +1,5 @@
 //! Renders the tasks view.
+use crankshaft_monitor::proto::TaskResourceUsageEvent;
 use ratatui::Frame;
 use ratatui::layout::Constraint;
 use ratatui::layout::Direction;
@@ -29,6 +30,7 @@ pub(crate) fn render_tasks(frame: &mut Frame<'_>, tasks_state: &mut TuiTasksStat
         "Name",
         "TES ID",
         "Status",
+        "Usage",
         "Last Update",
         "Message",
     ]
@@ -53,6 +55,7 @@ pub(crate) fn render_tasks(frame: &mut Frame<'_>, tasks_state: &mut TuiTasksStat
             Cell::from(task.name()),
             Cell::from(task.tes_id().unwrap_or_default()),
             Cell::from(task.status()),
+            Cell::from(format_usage(task.usage())),
             Cell::from(task.timestamp().to_string()),
             Cell::from(task.message()),
         ];
@@ -70,6 +73,7 @@ pub(crate) fn render_tasks(frame: &mut Frame<'_>, tasks_state: &mut TuiTasksStat
             Constraint::Max(20),
             Constraint::Max(20),
             Constraint::Max(10),
+            Constraint::Max(24),
             Constraint::Max(30),
             Constraint::Fill(1),
         ],
@@ -79,4 +83,23 @@ pub(crate) fn render_tasks(frame: &mut Frame<'_>, tasks_state: &mut TuiTasksStat
     .row_highlight_style(Style::default().bg(Color::DarkGray));
 
     frame.render_stateful_widget(table, area[0], &mut table_state);
+}
+
+/// Formats a task's latest resource usage for display.
+fn format_usage(usage: Option<&TaskResourceUsageEvent>) -> String {
+    let Some(usage) = usage else {
+        return String::new();
+    };
+
+    let mut parts = Vec::new();
+    if let Some(max) = usage.max_memory {
+        parts.push(format!(
+            "peak {:.1} GiB",
+            max as f64 / (1024.0 * 1024.0 * 1024.0)
+        ));
+    }
+    if let Some(cpu) = usage.cpu_time_ms {
+        parts.push(format!("cpu {:.1}s", cpu as f64 / 1000.0));
+    }
+    parts.join(", ")
 }

--- a/crankshaft-console/src/view/tasks.rs
+++ b/crankshaft-console/src/view/tasks.rs
@@ -93,13 +93,45 @@ fn format_usage(usage: Option<&TaskResourceUsageEvent>) -> String {
 
     let mut parts = Vec::new();
     if let Some(max) = usage.max_memory {
-        parts.push(format!(
-            "peak {:.1} GiB",
-            max as f64 / (1024.0 * 1024.0 * 1024.0)
-        ));
+        parts.push(format!("peak {}", format_bytes(max)));
     }
     if let Some(cpu) = usage.cpu_time_ms {
         parts.push(format!("cpu {:.1}s", cpu as f64 / 1000.0));
     }
     parts.join(", ")
+}
+
+/// Formats a byte count using a unit scaled to its magnitude.
+fn format_bytes(bytes: u64) -> String {
+    const UNITS: [&str; 4] = ["B", "KiB", "MiB", "GiB"];
+
+    let mut value = bytes as f64;
+    let mut unit = 0;
+    while value >= 1024.0 && unit < UNITS.len() - 1 {
+        value /= 1024.0;
+        unit += 1;
+    }
+
+    if unit == 0 {
+        format!("{bytes} B")
+    } else {
+        format!("{value:.1} {unit}", unit = UNITS[unit])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::format_bytes;
+
+    #[test]
+    fn bytes_format_with_scaled_units() {
+        assert_eq!(format_bytes(0), "0 B");
+        assert_eq!(format_bytes(512), "512 B");
+        assert_eq!(format_bytes(2048), "2.0 KiB");
+        assert_eq!(format_bytes(48 * 1024 * 1024), "48.0 MiB");
+        assert_eq!(
+            format_bytes(3 * 1024 * 1024 * 1024 + 512 * 1024 * 1024),
+            "3.5 GiB"
+        );
+    }
 }

--- a/crankshaft-docker/CHANGELOG.md
+++ b/crankshaft-docker/CHANGELOG.md
@@ -8,13 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
-#### Added
+### Added
 
 * Added `Container::stats` for sampling a container's current resource usage
   statistics ([#86](https://github.com/stjude-rust-labs/crankshaft/pull/86)).
-
-### Added
-
 * Added support for the `ImagePull{Started,Failed,Finished}` events ([#82](https://github.com/stjude-rust-labs/crankshaft/pull/82)).
 
 ## 0.5.0 - 04-22-2026

--- a/crankshaft-docker/CHANGELOG.md
+++ b/crankshaft-docker/CHANGELOG.md
@@ -11,7 +11,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 #### Added
 
 * Added `Container::stats` for sampling a container's current resource usage
-  statistics ([#XX](https://github.com/stjude-rust-labs/crankshaft/pull/XX)).
+  statistics ([#86](https://github.com/stjude-rust-labs/crankshaft/pull/86)).
 
 ### Added
 

--- a/crankshaft-docker/CHANGELOG.md
+++ b/crankshaft-docker/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+#### Added
+
+* Added `Container::stats` for sampling a container's current resource usage
+  statistics ([#XX](https://github.com/stjude-rust-labs/crankshaft/pull/XX)).
+
 ### Added
 
 * Added support for the `ImagePull{Started,Failed,Finished}` events ([#82](https://github.com/stjude-rust-labs/crankshaft/pull/82)).

--- a/crankshaft-docker/src/container.rs
+++ b/crankshaft-docker/src/container.rs
@@ -205,10 +205,12 @@ impl Container {
     pub async fn stats(&self) -> Result<Option<bollard::secret::ContainerStatsResponse>> {
         let mut stream = self.client.stats(
             &self.name,
-            Some(bollard::container::StatsOptions {
-                stream: false,
-                one_shot: true,
-            }),
+            Some(
+                bollard::query_parameters::StatsOptionsBuilder::default()
+                    .stream(false)
+                    .one_shot(true)
+                    .build(),
+            ),
         );
 
         match stream.next().await {

--- a/crankshaft-docker/src/container.rs
+++ b/crankshaft-docker/src/container.rs
@@ -197,6 +197,30 @@ impl Container {
         &self.name
     }
 
+    /// Samples the container's current resource usage statistics.
+    ///
+    /// Returns a single (one-shot) statistics sample from the Docker daemon,
+    /// or `None` if the daemon returned no sample (e.g. the container has
+    /// already exited).
+    pub async fn stats(&self) -> Result<Option<bollard::secret::ContainerStatsResponse>> {
+        let mut stream = self.client.stats(
+            &self.name,
+            Some(bollard::container::StatsOptions {
+                stream: false,
+                one_shot: true,
+            }),
+        );
+
+        match stream.next().await {
+            Some(Ok(stats)) => Ok(Some(stats)),
+            Some(Err(e)) => Err(Error::Message(format!(
+                "failed to sample stats for container `{name}`: {e}",
+                name = self.name
+            ))),
+            None => Ok(None),
+        }
+    }
+
     /// Runs a container and waits for the execution to end.
     pub async fn run(
         &self,

--- a/crankshaft-engine/CHANGELOG.md
+++ b/crankshaft-engine/CHANGELOG.md
@@ -14,6 +14,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   emit `TaskResourceUsage` events, gated by the new `resource-usage-interval`
   configuration; usage folds across a task's executions (memory maximum and
   average, cumulative CPU time) ([#XX](https://github.com/stjude-rust-labs/crankshaft/pull/XX)).
+* The TES backend can now read task resource usage from the documented
+  `TaskLog.metadata` keys and emit `TaskResourceUsage` events, gated by the
+  new `resource-usage-metadata` configuration; when enabled, tasks are polled
+  with the `BASIC` view ([#XX](https://github.com/stjude-rust-labs/crankshaft/pull/XX)).
 
 ### Changed
 

--- a/crankshaft-engine/CHANGELOG.md
+++ b/crankshaft-engine/CHANGELOG.md
@@ -8,6 +8,13 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Added
+
+* The Docker backend can now sample a running container's resource usage and
+  emit `TaskResourceUsage` events, gated by the new `resource-usage-interval`
+  configuration; usage folds across a task's executions (memory maximum and
+  average, cumulative CPU time) ([#XX](https://github.com/stjude-rust-labs/crankshaft/pull/XX)).
+
 ### Changed
 
 * `Execution`s can now specify multiple container images to act as fallbacks ([#83](https://github.com/stjude-rust-labs/crankshaft/pull/83)).

--- a/crankshaft-engine/CHANGELOG.md
+++ b/crankshaft-engine/CHANGELOG.md
@@ -13,11 +13,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 * The Docker backend can now sample a running container's resource usage and
   emit `TaskResourceUsage` events, gated by the new `resource-usage-interval`
   configuration; usage folds across a task's executions (memory maximum and
-  average, cumulative CPU time) ([#XX](https://github.com/stjude-rust-labs/crankshaft/pull/XX)).
+  average, cumulative CPU time) ([#86](https://github.com/stjude-rust-labs/crankshaft/pull/86)).
 * The TES backend can now read task resource usage from the documented
   `TaskLog.metadata` keys and emit `TaskResourceUsage` events, gated by the
   new `resource-usage-metadata` configuration; when enabled, tasks are polled
-  with the `BASIC` view ([#XX](https://github.com/stjude-rust-labs/crankshaft/pull/XX)).
+  with the `BASIC` view ([#86](https://github.com/stjude-rust-labs/crankshaft/pull/86)).
 
 ### Changed
 

--- a/crankshaft-engine/Cargo.toml
+++ b/crankshaft-engine/Cargo.toml
@@ -29,6 +29,7 @@ nix.workspace = true
 nonempty.workspace = true
 rand.workspace = true
 regex.workspace = true
+serde_json.workspace = true
 shlex.workspace = true
 ssh2.workspace = true
 tempfile.workspace = true

--- a/crankshaft-engine/Cargo.toml
+++ b/crankshaft-engine/Cargo.toml
@@ -18,6 +18,7 @@ anyhow.workspace = true
 async-trait.workspace = true
 bollard.workspace = true
 bon.workspace = true
+chrono.workspace = true
 crankshaft-config = { path = "../crankshaft-config", version = "0.6.0" }
 crankshaft-docker = { path = "../crankshaft-docker", version = "0.5.0" }
 crankshaft-events = { path = "../crankshaft-events", version = "0.1.0" }

--- a/crankshaft-engine/src/service/runner/backend/docker.rs
+++ b/crankshaft-engine/src/service/runner/backend/docker.rs
@@ -23,6 +23,7 @@ use crankshaft_docker::EventOptions;
 use crankshaft_docker::service::Service;
 use crankshaft_events::Event;
 use crankshaft_events::TaskId;
+use crankshaft_events::TaskResourceUsage;
 use crankshaft_events::next_task_id;
 use crankshaft_events::send_event;
 use futures::FutureExt;
@@ -138,6 +139,95 @@ impl Resources {
             Self::Local(_) => false,
             Self::Swarm(_) => true,
         }
+    }
+}
+
+/// Accumulates a task's resource usage across sampled container statistics.
+///
+/// A task may run more than one container (one per execution), and Docker's
+/// CPU counters are cumulative per container, so counters from finished
+/// containers are folded into offsets while memory statistics fold across all
+/// samples.
+#[derive(Debug, Default)]
+struct UsageFold {
+    /// The maximum memory usage observed across all samples, in bytes.
+    max_memory: Option<u64>,
+    /// The sum of sampled memory usage values, in bytes.
+    memory_sum: u128,
+    /// The number of memory samples taken.
+    memory_samples: u64,
+    /// Total CPU time of finished containers, in nanoseconds.
+    cpu_total_offset: u64,
+    /// User-mode CPU time of finished containers, in nanoseconds.
+    cpu_user_offset: u64,
+    /// System-mode CPU time of finished containers, in nanoseconds.
+    cpu_system_offset: u64,
+    /// The last observed cumulative total CPU time of the current container,
+    /// in nanoseconds.
+    cpu_total_last: u64,
+    /// The last observed cumulative user-mode CPU time of the current
+    /// container, in nanoseconds.
+    cpu_user_last: u64,
+    /// The last observed cumulative system-mode CPU time of the current
+    /// container, in nanoseconds.
+    cpu_system_last: u64,
+}
+
+impl UsageFold {
+    /// Folds a container statistics sample and returns the cumulative usage
+    /// snapshot.
+    fn observe(&mut self, stats: &bollard::secret::ContainerStatsResponse) -> TaskResourceUsage {
+        if let Some(usage) = stats.memory_stats.as_ref().and_then(|m| m.usage) {
+            self.max_memory = Some(self.max_memory.unwrap_or(0).max(usage));
+            self.memory_sum += usage as u128;
+            self.memory_samples += 1;
+        }
+
+        if let Some(cpu) = stats.cpu_stats.as_ref().and_then(|c| c.cpu_usage.as_ref()) {
+            if let Some(total) = cpu.total_usage {
+                self.cpu_total_last = total;
+            }
+            if let Some(user) = cpu.usage_in_usermode {
+                self.cpu_user_last = user;
+            }
+            if let Some(system) = cpu.usage_in_kernelmode {
+                self.cpu_system_last = system;
+            }
+        }
+
+        self.snapshot()
+    }
+
+    /// Folds the current container's cumulative CPU counters into the offsets
+    /// when the container finishes.
+    fn finish_container(&mut self) {
+        self.cpu_total_offset += self.cpu_total_last;
+        self.cpu_user_offset += self.cpu_user_last;
+        self.cpu_system_offset += self.cpu_system_last;
+        self.cpu_total_last = 0;
+        self.cpu_user_last = 0;
+        self.cpu_system_last = 0;
+    }
+
+    /// Produces the cumulative usage snapshot.
+    // `TaskResourceUsage` is `#[non_exhaustive]`, which prohibits both struct
+    // literal construction and functional update syntax from another crate.
+    #[allow(clippy::field_reassign_with_default)]
+    fn snapshot(&self) -> TaskResourceUsage {
+        /// Converts cumulative nanoseconds to milliseconds, mapping zero to
+        /// "not observed".
+        fn ns_to_ms(ns: u64) -> Option<i64> {
+            (ns > 0).then_some((ns / 1_000_000) as i64)
+        }
+
+        let mut usage = TaskResourceUsage::default();
+        usage.max_memory = self.max_memory;
+        usage.avg_memory = (self.memory_samples > 0)
+            .then(|| (self.memory_sum / self.memory_samples as u128) as u64);
+        usage.cpu_time_ms = ns_to_ms(self.cpu_total_offset + self.cpu_total_last);
+        usage.user_cpu_time_ms = ns_to_ms(self.cpu_user_offset + self.cpu_user_last);
+        usage.system_cpu_time_ms = ns_to_ms(self.cpu_system_offset + self.cpu_system_last);
+        usage
     }
 }
 
@@ -428,6 +518,7 @@ impl crate::Backend for Backend {
         let client = self.client.clone();
         let run_cleanup = self.config.cleanup();
         let events_config = self.config.events();
+        let resource_usage_interval = self.config.resource_usage_interval();
         let use_service = self.resources.use_service();
         let events = self.events.clone();
         let names = self.names.clone();
@@ -441,6 +532,10 @@ impl crate::Backend for Backend {
                 // SAFETY: the name generator should _never_ run out of entries.
                 generator.next().unwrap()
             });
+
+            // Accumulates the task's resource usage across every execution's
+            // sampled container statistics.
+            let usage = Arc::new(Mutex::new(UsageFold::default()));
 
             let run = async {
                 let tempdir = TempDir::new().context("failed to create temporary directory for mounts")?;
@@ -589,7 +684,53 @@ impl crate::Backend for Backend {
 
                         info!("created container `{name}` (task `{task_name}`)", name = container.name());
 
-                        select! {
+                        // Sample the container's resource usage while it
+                        // runs, when sampling is configured and there is an
+                        // events channel to report on.
+                        let sampler = match (resource_usage_interval, events.clone()) {
+                            (Some(secs), Some(events)) => {
+                                let container = container.clone();
+                                let usage = usage.clone();
+                                Some(tokio::spawn(async move {
+                                    let mut interval = tokio::time::interval(
+                                        std::time::Duration::from_secs(secs),
+                                    );
+                                    interval.set_missed_tick_behavior(
+                                        tokio::time::MissedTickBehavior::Delay,
+                                    );
+                                    // The first tick completes immediately;
+                                    // skip it so sampling starts one interval
+                                    // into the container's run.
+                                    interval.tick().await;
+                                    loop {
+                                        interval.tick().await;
+                                        match container.stats().await {
+                                            Ok(Some(stats)) => {
+                                                let snapshot =
+                                                    usage.lock().unwrap().observe(&stats);
+                                                let _ = events.send(Event::TaskResourceUsage {
+                                                    id: task_id,
+                                                    usage: snapshot,
+                                                });
+                                            }
+                                            // The container has already
+                                            // exited; stop sampling.
+                                            Ok(None) => break,
+                                            Err(e) => {
+                                                debug!(
+                                                    "failed to sample resource usage for \
+                                                     container `{name}`: {e:#}",
+                                                    name = container.name()
+                                                );
+                                            }
+                                        }
+                                    }
+                                }))
+                            }
+                            _ => None,
+                        };
+
+                        let result = select! {
                             // Always poll the cancellation token first
                             biased;
                             _ = task_token.cancelled() => {
@@ -601,7 +742,16 @@ impl crate::Backend for Backend {
                             res = container.run(&task_name, options) => {
                                 (res.context("failed to run Docker container").map_err(TaskRunError::Other), Cleanup::Container(container))
                             }
+                        };
+
+                        // Stop sampling and fold the finished container's
+                        // cumulative CPU counters into the task's offsets.
+                        if let Some(sampler) = sampler {
+                            sampler.abort();
                         }
+                        usage.lock().unwrap().finish_container();
+
+                        result
                     };
 
                     if run_cleanup {
@@ -936,5 +1086,84 @@ mod test {
         );
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod usage_tests {
+    use bollard::secret::ContainerCpuStats;
+    use bollard::secret::ContainerCpuUsage;
+    use bollard::secret::ContainerMemoryStats;
+    use bollard::secret::ContainerStatsResponse;
+
+    use super::UsageFold;
+
+    /// Builds a stats sample with the given memory usage (bytes) and
+    /// cumulative CPU counters (nanoseconds).
+    fn sample(memory: u64, total: u64, user: u64, system: u64) -> ContainerStatsResponse {
+        ContainerStatsResponse {
+            memory_stats: Some(ContainerMemoryStats {
+                usage: Some(memory),
+                ..Default::default()
+            }),
+            cpu_stats: Some(ContainerCpuStats {
+                cpu_usage: Some(ContainerCpuUsage {
+                    total_usage: Some(total),
+                    usage_in_usermode: Some(user),
+                    usage_in_kernelmode: Some(system),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn usage_folds_memory_and_cumulative_cpu() {
+        let mut fold = UsageFold::default();
+
+        let usage = fold.observe(&sample(100, 1_000_000, 600_000, 400_000));
+        assert_eq!(usage.max_memory, Some(100));
+        assert_eq!(usage.avg_memory, Some(100));
+        assert_eq!(usage.cpu_time_ms, Some(1));
+
+        // Memory folds max and average; CPU counters are cumulative, so the
+        // latest sample wins.
+        let usage = fold.observe(&sample(300, 4_000_000, 3_000_000, 1_000_000));
+        assert_eq!(usage.max_memory, Some(300));
+        assert_eq!(usage.avg_memory, Some(200));
+        assert_eq!(usage.cpu_time_ms, Some(4));
+        assert_eq!(usage.user_cpu_time_ms, Some(3));
+        assert_eq!(usage.system_cpu_time_ms, Some(1));
+
+        // A lower memory sample lowers the average but not the maximum.
+        let usage = fold.observe(&sample(200, 5_000_000, 3_500_000, 1_500_000));
+        assert_eq!(usage.max_memory, Some(300));
+        assert_eq!(usage.avg_memory, Some(200));
+        assert_eq!(usage.cpu_time_ms, Some(5));
+    }
+
+    #[test]
+    fn usage_accumulates_cpu_across_containers() {
+        let mut fold = UsageFold::default();
+
+        // First execution's container consumes 5ms of CPU.
+        fold.observe(&sample(100, 5_000_000, 4_000_000, 1_000_000));
+        fold.finish_container();
+
+        // The second execution's container restarts its cumulative counters;
+        // the fold must sum across containers rather than regress.
+        let usage = fold.observe(&sample(200, 2_000_000, 1_000_000, 1_000_000));
+        assert_eq!(usage.cpu_time_ms, Some(7));
+        assert_eq!(usage.user_cpu_time_ms, Some(5));
+        assert_eq!(usage.system_cpu_time_ms, Some(2));
+        assert_eq!(usage.max_memory, Some(200));
+    }
+
+    #[test]
+    fn empty_folds_produce_empty_snapshots() {
+        let fold = UsageFold::default();
+        assert!(fold.snapshot().is_empty());
     }
 }

--- a/crankshaft-engine/src/service/runner/backend/docker.rs
+++ b/crankshaft-engine/src/service/runner/backend/docker.rs
@@ -154,6 +154,9 @@ struct UsageFold {
     /// The maximum memory usage observed across all samples, in bytes.
     max_memory: Option<u64>,
     /// The sum of sampled memory usage values, in bytes.
+    ///
+    /// The reported average is the arithmetic mean of the polled samples; it
+    /// is not time-weighted, so missed or delayed sampling ticks skew it.
     memory_sum: u128,
     /// The number of memory samples taken.
     memory_samples: u64,
@@ -420,6 +423,21 @@ impl Backend {
             }
         };
 
+        // Resource usage sampling applies only to local container execution;
+        // warn once (rather than silently ignore) when it is configured for a
+        // Docker Swarm service
+        if resources.use_service()
+            && config
+                .resource_usage_interval()
+                .filter(|i| *i > 0)
+                .is_some()
+        {
+            warn!(
+                "`resource-usage-interval` is not supported for Docker Swarm services; resource \
+                 usage will not be sampled"
+            );
+        }
+
         Ok(Self {
             client,
             config,
@@ -540,16 +558,6 @@ impl crate::Backend for Backend {
         // panics on a zero duration
         let resource_usage_interval = self.config.resource_usage_interval().filter(|i| *i > 0);
         let use_service = self.resources.use_service();
-
-        // Resource usage sampling applies only to local container execution;
-        // warn (rather than silently ignore) when it is configured for a
-        // Docker Swarm service
-        if use_service && resource_usage_interval.is_some() {
-            warn!(
-                "`resource-usage-interval` is not supported for Docker Swarm services; resource \
-                 usage will not be sampled"
-            );
-        }
         let events = self.events.clone();
         let names = self.names.clone();
 

--- a/crankshaft-engine/src/service/runner/backend/docker.rs
+++ b/crankshaft-engine/src/service/runner/backend/docker.rs
@@ -204,15 +204,18 @@ impl UsageFold {
             self.memory_samples += 1;
         }
 
+        // The counters are kept monotonic: Docker returns a successful,
+        // zero-valued stats object once a container has exited, and a sample
+        // landing in that gap must not reset previously observed CPU time
         if let Some(cpu) = stats.cpu_stats.as_ref().and_then(|c| c.cpu_usage.as_ref()) {
             if let Some(total) = cpu.total_usage {
-                self.cpu_total_last = total;
+                self.cpu_total_last = self.cpu_total_last.max(total);
             }
             if let Some(user) = cpu.usage_in_usermode {
-                self.cpu_user_last = user;
+                self.cpu_user_last = self.cpu_user_last.max(user);
             }
             if let Some(system) = cpu.usage_in_kernelmode {
-                self.cpu_system_last = system;
+                self.cpu_system_last = self.cpu_system_last.max(system);
             }
         }
 
@@ -237,8 +240,8 @@ impl UsageFold {
     fn snapshot(&self) -> TaskResourceUsage {
         /// Converts cumulative nanoseconds to milliseconds, mapping zero to
         /// "not observed".
-        fn ns_to_ms(ns: u64) -> Option<i64> {
-            (ns > 0).then_some((ns / 1_000_000) as i64)
+        fn ns_to_ms(ns: u64) -> Option<u64> {
+            (ns > 0).then_some(ns / 1_000_000)
         }
 
         let mut usage = TaskResourceUsage::default();
@@ -736,10 +739,18 @@ impl crate::Backend for Backend {
                                             Ok(Some(stats)) => {
                                                 let snapshot =
                                                     usage.lock().unwrap().observe(&stats);
-                                                let _ = events.send(Event::TaskResourceUsage {
-                                                    id: task_id,
-                                                    usage: snapshot,
-                                                });
+                                                // Docker can return a
+                                                // successful sample carrying
+                                                // no measurements; skip
+                                                // snapshots with nothing to
+                                                // report
+                                                if !snapshot.is_empty() {
+                                                    let _ =
+                                                        events.send(Event::TaskResourceUsage {
+                                                            id: task_id,
+                                                            usage: snapshot,
+                                                        });
+                                                }
                                             }
                                             // The container has already
                                             // exited; stop sampling.
@@ -1261,6 +1272,25 @@ mod usage_tests {
     fn empty_folds_produce_empty_snapshots() {
         let fold = UsageFold::default();
         assert!(fold.snapshot().is_empty());
+    }
+
+    #[test]
+    fn zero_valued_samples_do_not_reset_cpu_counters() {
+        let mut fold = UsageFold::default();
+
+        fold.observe(&sample(100, 5_000_000, 4_000_000, 1_000_000));
+
+        // Docker returns a successful, zero-valued stats object once a
+        // container has exited; such a sample must not reset the counters
+        let usage = fold.observe(&sample(0, 0, 0, 0));
+        assert_eq!(usage.cpu_time_ms, Some(5));
+        assert_eq!(usage.user_cpu_time_ms, Some(4));
+        assert_eq!(usage.system_cpu_time_ms, Some(1));
+
+        // And the real values are banked, not the zeroes
+        fold.finish_container();
+        let usage = fold.snapshot();
+        assert_eq!(usage.cpu_time_ms, Some(5));
     }
 
     #[test]

--- a/crankshaft-engine/src/service/runner/backend/docker.rs
+++ b/crankshaft-engine/src/service/runner/backend/docker.rs
@@ -35,6 +35,7 @@ use tokio::sync::broadcast;
 use tokio_util::sync::CancellationToken;
 use tracing::debug;
 use tracing::info;
+use tracing::warn;
 
 use super::TaskRunError;
 use crate::Task;
@@ -177,7 +178,24 @@ impl UsageFold {
     /// Folds a container statistics sample and returns the cumulative usage
     /// snapshot.
     fn observe(&mut self, stats: &bollard::secret::ContainerStatsResponse) -> TaskResourceUsage {
-        if let Some(usage) = stats.memory_stats.as_ref().and_then(|m| m.usage) {
+        if let Some(memory) = stats.memory_stats.as_ref()
+            && let Some(usage) = memory.usage
+        {
+            // Docker's raw `usage` includes reclaimable page cache; follow
+            // the Docker CLI's semantics by subtracting the inactive file
+            // cache (`inactive_file` on cgroup v2, `total_inactive_file` on
+            // cgroup v1) so that folded values reflect memory actually held
+            let cache = memory
+                .stats
+                .as_ref()
+                .and_then(|s| {
+                    s.get("inactive_file")
+                        .or_else(|| s.get("total_inactive_file"))
+                })
+                .copied()
+                .unwrap_or(0);
+            let usage = usage.saturating_sub(cache);
+
             self.max_memory = Some(self.max_memory.unwrap_or(0).max(usage));
             self.memory_sum += usage as u128;
             self.memory_samples += 1;
@@ -518,8 +536,20 @@ impl crate::Backend for Backend {
         let client = self.client.clone();
         let run_cleanup = self.config.cleanup();
         let events_config = self.config.events();
-        let resource_usage_interval = self.config.resource_usage_interval();
+        // A zero interval is normalized to disabled: Tokio's `interval`
+        // panics on a zero duration
+        let resource_usage_interval = self.config.resource_usage_interval().filter(|i| *i > 0);
         let use_service = self.resources.use_service();
+
+        // Resource usage sampling applies only to local container execution;
+        // warn (rather than silently ignore) when it is configured for a
+        // Docker Swarm service
+        if use_service && resource_usage_interval.is_some() {
+            warn!(
+                "`resource-usage-interval` is not supported for Docker Swarm services; resource \
+                 usage will not be sampled"
+            );
+        }
         let events = self.events.clone();
         let names = self.names.clone();
 
@@ -745,9 +775,12 @@ impl crate::Backend for Backend {
                         };
 
                         // Stop sampling and fold the finished container's
-                        // cumulative CPU counters into the task's offsets.
+                        // cumulative CPU counters into the task's offsets;
+                        // await the aborted sampler so that no in-flight
+                        // observation can land after the counters are banked.
                         if let Some(sampler) = sampler {
                             sampler.abort();
+                            let _ = sampler.await;
                         }
                         usage.lock().unwrap().finish_container();
 
@@ -1165,5 +1198,38 @@ mod usage_tests {
     fn empty_folds_produce_empty_snapshots() {
         let fold = UsageFold::default();
         assert!(fold.snapshot().is_empty());
+    }
+
+    #[test]
+    fn usage_subtracts_inactive_file_cache() {
+        /// Builds a stats sample with the given memory usage and a cache
+        /// entry under the given stat key.
+        fn cached_sample(memory: u64, key: &str, cache: u64) -> ContainerStatsResponse {
+            ContainerStatsResponse {
+                memory_stats: Some(ContainerMemoryStats {
+                    usage: Some(memory),
+                    stats: Some([(key.to_string(), cache)].into_iter().collect()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }
+        }
+
+        // cgroup v2 reports `inactive_file`
+        let mut fold = UsageFold::default();
+        let usage = fold.observe(&cached_sample(1000, "inactive_file", 300));
+        assert_eq!(usage.max_memory, Some(700));
+        assert_eq!(usage.avg_memory, Some(700));
+
+        // cgroup v1 reports `total_inactive_file`
+        let mut fold = UsageFold::default();
+        let usage = fold.observe(&cached_sample(1000, "total_inactive_file", 250));
+        assert_eq!(usage.max_memory, Some(750));
+
+        // A cache value larger than usage saturates to zero rather than
+        // wrapping
+        let mut fold = UsageFold::default();
+        let usage = fold.observe(&cached_sample(100, "inactive_file", 500));
+        assert_eq!(usage.max_memory, Some(0));
     }
 }

--- a/crankshaft-engine/src/service/runner/backend/tes.rs
+++ b/crankshaft-engine/src/service/runner/backend/tes.rs
@@ -70,6 +70,9 @@ struct BackendState {
     permits: Semaphore,
     /// The events sender for Crankshaft events.
     events: Option<broadcast::Sender<Event>>,
+    /// Whether to read task resource usage from the server's task log
+    /// metadata.
+    resource_usage_metadata: bool,
 }
 
 impl BackendState {
@@ -124,7 +127,7 @@ impl Backend {
         names: Arc<Mutex<GeneratorIterator<UniqueAlphanumeric>>>,
         events: Option<broadcast::Sender<Event>>,
     ) -> Self {
-        let (url, http, interval) = config.into_parts();
+        let (url, http, interval, resource_usage_metadata) = config.into_parts();
         let mut builder = Client::builder().url(url);
 
         if let Some(auth) = &http.auth {
@@ -144,6 +147,7 @@ impl Backend {
                     .unwrap_or(DEFAULT_MAX_CONCURRENT_REQUESTS),
             ),
             events,
+            resource_usage_metadata,
         });
 
         // SAFETY: the name generator should _never_ run out of entries.

--- a/crankshaft-engine/src/service/runner/backend/tes/monitor.rs
+++ b/crankshaft-engine/src/service/runner/backend/tes/monitor.rs
@@ -43,7 +43,8 @@ struct MonitoredTaskState {
 /// strings:
 ///
 /// * `peak_memory_bytes` — peak sampled memory, in bytes
-/// * `avg_memory_bytes` — average sampled memory, in bytes
+/// * `avg_memory_bytes` — average sampled memory, in bytes; the averaging
+///   method is server-defined
 /// * `cpu_time_ms` — total CPU time, in milliseconds
 /// * `user_cpu_time_ms` — user-mode CPU time, in milliseconds
 /// * `system_cpu_time_ms` — system-mode CPU time, in milliseconds

--- a/crankshaft-engine/src/service/runner/backend/tes/monitor.rs
+++ b/crankshaft-engine/src/service/runner/backend/tes/monitor.rs
@@ -11,6 +11,7 @@ use anyhow::Result;
 use anyhow::anyhow;
 use crankshaft_events::Event;
 use crankshaft_events::TaskId;
+use crankshaft_events::TaskResourceUsage;
 use crankshaft_events::send_event;
 use tes::v1::types::requests::ListTasksParams;
 use tes::v1::types::requests::MAX_PAGE_SIZE;
@@ -25,6 +26,59 @@ use tracing::info;
 
 /// The name of the tag used to group tasks together for monitoring.
 pub const CRANKSHAFT_GROUP_TAG_NAME: &str = "crankshaft-task-group";
+
+/// The identifier and state extracted from a polled TES task.
+struct MonitoredTaskState {
+    /// The TES task identifier.
+    id: String,
+    /// The TES task state.
+    state: Option<TesState>,
+}
+
+/// Parses the documented resource usage keys from a TES task log's metadata.
+///
+/// The TES specification designates `TaskLog.metadata` for
+/// implementation-specific data; servers that report resource usage are
+/// expected to use the following keys, with values as JSON numbers or numeric
+/// strings:
+///
+/// * `peak_rss_bytes` — maximum resident memory, in bytes
+/// * `avg_rss_bytes` — average resident memory, in bytes
+/// * `cpu_time_ms` — total CPU time, in milliseconds
+/// * `user_cpu_time_ms` — user-mode CPU time, in milliseconds
+/// * `system_cpu_time_ms` — system-mode CPU time, in milliseconds
+/// * `disk_used_bytes` — disk space used, in bytes
+///
+/// Unknown keys and unparseable values are ignored.
+#[allow(clippy::field_reassign_with_default)]
+fn parse_resource_usage_metadata(metadata: &serde_json::Value) -> TaskResourceUsage {
+    /// Gets a numeric metadata value as a `u64`, accepting JSON numbers and
+    /// numeric strings.
+    fn get_u64(metadata: &serde_json::Value, key: &str) -> Option<u64> {
+        let value = metadata.get(key)?;
+        value
+            .as_u64()
+            .or_else(|| value.as_str().and_then(|s| s.trim().parse().ok()))
+    }
+
+    /// Gets a numeric metadata value as an `i64`, accepting JSON numbers and
+    /// numeric strings.
+    fn get_i64(metadata: &serde_json::Value, key: &str) -> Option<i64> {
+        let value = metadata.get(key)?;
+        value
+            .as_i64()
+            .or_else(|| value.as_str().and_then(|s| s.trim().parse().ok()))
+    }
+
+    let mut usage = TaskResourceUsage::default();
+    usage.max_memory = get_u64(metadata, "peak_rss_bytes");
+    usage.avg_memory = get_u64(metadata, "avg_rss_bytes");
+    usage.cpu_time_ms = get_i64(metadata, "cpu_time_ms");
+    usage.user_cpu_time_ms = get_i64(metadata, "user_cpu_time_ms");
+    usage.system_cpu_time_ms = get_i64(metadata, "system_cpu_time_ms");
+    usage.disk_used = get_u64(metadata, "disk_used_bytes");
+    usage
+}
 
 /// Represents a monitored task.
 #[derive(Debug)]
@@ -178,7 +232,13 @@ impl TaskMonitor {
                             tag_values: Some(vec![tag]),
                             page_size: Some(MAX_PAGE_SIZE - 1),
                             page_token,
-                            view: Some(View::Minimal),
+                            view: Some(if backend_state.resource_usage_metadata {
+                                // The `BASIC` view includes task logs, whose
+                                // metadata may carry resource usage.
+                                View::Basic
+                            } else {
+                                View::Minimal
+                            }),
                             ..Default::default()
                         }),
                         backend_state.policy(),
@@ -200,10 +260,43 @@ impl TaskMonitor {
                     let mut state = state.lock().expect("failed to TES lock monitor state");
 
                     // For any task that is completed and in the map, notify of completion
-                    for task in tes_tasks
-                        .into_iter()
-                        .map(|t| t.into_minimal().expect("task should be minimal"))
-                    {
+                    for task in tes_tasks {
+                        // Extract the identifier, state, and any reported
+                        // resource usage from whichever view was requested.
+                        let (task_id, task_state, usage) = match task {
+                            tes::v1::types::responses::TaskResponse::Minimal(t) => {
+                                (t.id, t.state, None)
+                            }
+                            t => {
+                                let t = t.into_task().expect("task should be basic");
+                                let usage = t
+                                    .logs
+                                    .as_ref()
+                                    .and_then(|logs| logs.last())
+                                    .and_then(|log| log.metadata.as_ref())
+                                    .map(parse_resource_usage_metadata)
+                                    .filter(|usage| !usage.is_empty());
+                                (t.id.unwrap_or_default(), t.state, usage)
+                            }
+                        };
+
+                        // Report any resource usage the server included; each
+                        // report is a cumulative snapshot and the last one
+                        // received is authoritative.
+                        if let Some(usage) = usage
+                            && let Some(id) = state.ids.get(&task_id).copied()
+                        {
+                            send_event!(
+                                backend_state.events,
+                                Event::TaskResourceUsage { id, usage }
+                            );
+                        }
+
+                        let task = MonitoredTaskState {
+                            id: task_id,
+                            state: task_state,
+                        };
+
                         match task.state.unwrap_or_default() {
                             TesState::Running | TesState::Paused => {
                                 // The task is now running, send the started event
@@ -286,5 +379,49 @@ impl TaskMonitor {
         }
 
         info!("TES task monitor has shut down");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn metadata_parses_numbers_and_numeric_strings() {
+        let metadata = serde_json::json!({
+            "peak_rss_bytes": 1073741824u64,
+            "avg_rss_bytes": "536870912",
+            "cpu_time_ms": "12500 ",
+            "user_cpu_time_ms": 12000,
+            "system_cpu_time_ms": 500,
+            "disk_used_bytes": "2147483648",
+            "some_other_key": "ignored",
+        });
+
+        let usage = parse_resource_usage_metadata(&metadata);
+        assert_eq!(usage.max_memory, Some(1073741824));
+        assert_eq!(usage.avg_memory, Some(536870912));
+        assert_eq!(usage.cpu_time_ms, Some(12500));
+        assert_eq!(usage.user_cpu_time_ms, Some(12000));
+        assert_eq!(usage.system_cpu_time_ms, Some(500));
+        assert_eq!(usage.disk_used, Some(2147483648));
+        assert!(!usage.is_empty());
+    }
+
+    #[test]
+    fn unparseable_and_missing_metadata_is_ignored() {
+        let metadata = serde_json::json!({
+            "peak_rss_bytes": "not a number",
+            "cpu_time_ms": true,
+        });
+
+        let usage = parse_resource_usage_metadata(&metadata);
+        assert!(usage.is_empty());
+
+        let usage = parse_resource_usage_metadata(&serde_json::json!("free-form string"));
+        assert!(usage.is_empty());
+
+        let usage = parse_resource_usage_metadata(&serde_json::json!({}));
+        assert!(usage.is_empty());
     }
 }

--- a/crankshaft-engine/src/service/runner/backend/tes/monitor.rs
+++ b/crankshaft-engine/src/service/runner/backend/tes/monitor.rs
@@ -100,6 +100,9 @@ struct TaskMonitorState {
     ids: HashMap<String, TaskId>,
     /// Set of known running tasks
     running: HashSet<TaskId>,
+    /// The last resource usage snapshot sent for each task, used to avoid
+    /// resending identical snapshots on every poll.
+    usage: HashMap<TaskId, TaskResourceUsage>,
 }
 
 /// Represents a TES task monitor.
@@ -183,9 +186,10 @@ impl TaskMonitor {
     /// Removes a task from the monitor.
     pub async fn remove_task(&self, tes_id: &str) {
         let mut state = self.state.lock().expect("failed to lock TES monitor state");
-        if let Some(id) = state.ids.get(tes_id).copied() {
+        if let Some(id) = state.ids.remove(tes_id) {
             state.tasks.remove(&id);
             state.running.remove(&id);
+            state.usage.remove(&id);
         }
     }
 
@@ -282,10 +286,15 @@ impl TaskMonitor {
 
                         // Report any resource usage the server included; each
                         // report is a cumulative snapshot and the last one
-                        // received is authoritative.
+                        // received is authoritative. Only emit for tasks that
+                        // are still monitored, and only when the snapshot
+                        // changed since the last emission.
                         if let Some(usage) = usage
                             && let Some(id) = state.ids.get(&task_id).copied()
+                            && state.tasks.contains_key(&id)
+                            && state.usage.get(&id) != Some(&usage)
                         {
+                            state.usage.insert(id, usage.clone());
                             send_event!(
                                 backend_state.events,
                                 Event::TaskResourceUsage { id, usage }
@@ -321,6 +330,7 @@ impl TaskMonitor {
                                 // The task has completed, send the completion message
                                 if let Some(id) = state.ids.remove(&task.id) {
                                     state.running.remove(&id);
+                                    state.usage.remove(&id);
                                     if let Some(task) = state.tasks.remove(&id) {
                                         let _ = task.completed.send(Ok(()));
                                     }

--- a/crankshaft-engine/src/service/runner/backend/tes/monitor.rs
+++ b/crankshaft-engine/src/service/runner/backend/tes/monitor.rs
@@ -42,8 +42,8 @@ struct MonitoredTaskState {
 /// expected to use the following keys, with values as JSON numbers or numeric
 /// strings:
 ///
-/// * `peak_rss_bytes` — maximum resident memory, in bytes
-/// * `avg_rss_bytes` — average resident memory, in bytes
+/// * `peak_memory_bytes` — peak sampled memory, in bytes
+/// * `avg_memory_bytes` — average sampled memory, in bytes
 /// * `cpu_time_ms` — total CPU time, in milliseconds
 /// * `user_cpu_time_ms` — user-mode CPU time, in milliseconds
 /// * `system_cpu_time_ms` — system-mode CPU time, in milliseconds
@@ -71,8 +71,8 @@ fn parse_resource_usage_metadata(metadata: &serde_json::Value) -> TaskResourceUs
     }
 
     let mut usage = TaskResourceUsage::default();
-    usage.max_memory = get_u64(metadata, "peak_rss_bytes");
-    usage.avg_memory = get_u64(metadata, "avg_rss_bytes");
+    usage.max_memory = get_u64(metadata, "peak_memory_bytes");
+    usage.avg_memory = get_u64(metadata, "avg_memory_bytes");
     usage.cpu_time_ms = get_i64(metadata, "cpu_time_ms");
     usage.user_cpu_time_ms = get_i64(metadata, "user_cpu_time_ms");
     usage.system_cpu_time_ms = get_i64(metadata, "system_cpu_time_ms");
@@ -389,8 +389,8 @@ mod tests {
     #[test]
     fn metadata_parses_numbers_and_numeric_strings() {
         let metadata = serde_json::json!({
-            "peak_rss_bytes": 1073741824u64,
-            "avg_rss_bytes": "536870912",
+            "peak_memory_bytes": 1073741824u64,
+            "avg_memory_bytes": "536870912",
             "cpu_time_ms": "12500 ",
             "user_cpu_time_ms": 12000,
             "system_cpu_time_ms": 500,
@@ -411,7 +411,7 @@ mod tests {
     #[test]
     fn unparseable_and_missing_metadata_is_ignored() {
         let metadata = serde_json::json!({
-            "peak_rss_bytes": "not a number",
+            "peak_memory_bytes": "not a number",
             "cpu_time_ms": true,
         });
 

--- a/crankshaft-engine/src/service/runner/backend/tes/monitor.rs
+++ b/crankshaft-engine/src/service/runner/backend/tes/monitor.rs
@@ -63,23 +63,99 @@ fn parse_resource_usage_metadata(metadata: &serde_json::Value) -> TaskResourceUs
             .or_else(|| value.as_str().and_then(|s| s.trim().parse().ok()))
     }
 
-    /// Gets a numeric metadata value as an `i64`, accepting JSON numbers and
-    /// numeric strings.
-    fn get_i64(metadata: &serde_json::Value, key: &str) -> Option<i64> {
-        let value = metadata.get(key)?;
-        value
-            .as_i64()
-            .or_else(|| value.as_str().and_then(|s| s.trim().parse().ok()))
-    }
-
     let mut usage = TaskResourceUsage::default();
     usage.max_memory = get_u64(metadata, "peak_memory_bytes");
     usage.avg_memory = get_u64(metadata, "avg_memory_bytes");
-    usage.cpu_time_ms = get_i64(metadata, "cpu_time_ms");
-    usage.user_cpu_time_ms = get_i64(metadata, "user_cpu_time_ms");
-    usage.system_cpu_time_ms = get_i64(metadata, "system_cpu_time_ms");
+    usage.cpu_time_ms = get_u64(metadata, "cpu_time_ms");
+    usage.user_cpu_time_ms = get_u64(metadata, "user_cpu_time_ms");
+    usage.system_cpu_time_ms = get_u64(metadata, "system_cpu_time_ms");
     usage.disk_used = get_u64(metadata, "disk_used_bytes");
     usage
+}
+
+/// Folds resource usage from a task's logs into a cumulative snapshot.
+///
+/// TES servers create a new `TaskLog` for each internal retry, so usage must
+/// be folded across every attempt rather than read from the latest log:
+///
+/// * peak memory and disk used take the maximum across attempts;
+/// * CPU times sum across attempts (saturating);
+/// * average memory is the duration-weighted mean of the attempts' averages,
+///   weighted by each log's `start_time`/`end_time` span (an attempt still in
+///   flight is weighted by the time elapsed since its start); if any
+///   contributing log lacks timestamps, an unweighted mean is used instead.
+///
+/// Returns `None` if no log carries any usage.
+fn fold_task_log_usage(logs: &[tes::v1::types::responses::TaskLog]) -> Option<TaskResourceUsage> {
+    /// An attempt's average memory and its duration weight, in seconds.
+    struct Average {
+        /// The attempt's reported average memory, in bytes.
+        avg: u64,
+        /// The attempt's duration, in seconds, if its log carries timestamps.
+        weight: Option<f64>,
+    }
+
+    let mut usage = TaskResourceUsage::default();
+    let mut averages = Vec::new();
+    let mut any = false;
+
+    for log in logs {
+        let Some(metadata) = log.metadata.as_ref() else {
+            continue;
+        };
+
+        let parsed = parse_resource_usage_metadata(metadata);
+        if parsed.is_empty() {
+            continue;
+        }
+
+        any = true;
+
+        if let Some(peak) = parsed.max_memory {
+            usage.max_memory = Some(usage.max_memory.unwrap_or(0).max(peak));
+        }
+
+        if let Some(disk) = parsed.disk_used {
+            usage.disk_used = Some(usage.disk_used.unwrap_or(0).max(disk));
+        }
+
+        for (total, value) in [
+            (&mut usage.cpu_time_ms, parsed.cpu_time_ms),
+            (&mut usage.user_cpu_time_ms, parsed.user_cpu_time_ms),
+            (&mut usage.system_cpu_time_ms, parsed.system_cpu_time_ms),
+        ] {
+            if let Some(value) = value {
+                *total = Some(total.unwrap_or(0).saturating_add(value));
+            }
+        }
+
+        if let Some(avg) = parsed.avg_memory {
+            let weight = log.start_time.map(|start| {
+                let end = log.end_time.unwrap_or_else(chrono::Utc::now);
+                (end - start).num_milliseconds().max(0) as f64 / 1_000.0
+            });
+            averages.push(Average { avg, weight });
+        }
+    }
+
+    if !averages.is_empty() {
+        // Weight by duration only when every contributing attempt has one
+        let weighted = averages.iter().all(|a| a.weight.is_some());
+        let mut sum = 0.0;
+        let mut total_weight = 0.0;
+        for a in &averages {
+            let weight = if weighted {
+                a.weight.expect("checked above").max(f64::EPSILON)
+            } else {
+                1.0
+            };
+            sum += a.avg as f64 * weight;
+            total_weight += weight;
+        }
+        usage.avg_memory = Some((sum / total_weight) as u64);
+    }
+
+    if any { Some(usage) } else { None }
 }
 
 /// Represents a monitored task.
@@ -224,7 +300,7 @@ impl TaskMonitor {
         backend_state: &super::BackendState,
     ) {
         let mut page_token = None;
-        loop {
+        'poll: loop {
             // Get the current tag from the state
             let tag = {
                 let state = state.lock().expect("failed to TES lock monitor state");
@@ -295,14 +371,31 @@ impl TaskMonitor {
                             }
                             t => {
                                 let t = t.into_task().expect("task should be basic");
+
+                                // A task response without an identifier
+                                // cannot be attributed to any monitored task;
+                                // if it were ignored, that task's terminal
+                                // state would never be observed and its
+                                // runner would wait forever. Fail the
+                                // monitored tasks explicitly instead.
+                                let Some(id) = t.id else {
+                                    state.running.clear();
+                                    state.ids.clear();
+                                    state.usage.clear();
+                                    for (_, task) in state.tasks.drain() {
+                                        let _ = task.completed.send(Err(anyhow!(
+                                            "TES server returned a task response without an id"
+                                        )));
+                                    }
+                                    break 'poll;
+                                };
+
                                 let usage = t
                                     .logs
-                                    .as_ref()
-                                    .and_then(|logs| logs.last())
-                                    .and_then(|log| log.metadata.as_ref())
-                                    .map(parse_resource_usage_metadata)
+                                    .as_deref()
+                                    .and_then(fold_task_log_usage)
                                     .filter(|usage| !usage.is_empty());
-                                (t.id.unwrap_or_default(), t.state, usage)
+                                (id, t.state, usage)
                             }
                         };
 
@@ -414,7 +507,85 @@ impl TaskMonitor {
 
 #[cfg(test)]
 mod tests {
+    use tes::v1::types::responses::TaskLog;
+
     use super::*;
+
+    /// Builds a task log with the given metadata and optional start/end
+    /// times (RFC 3339).
+    fn task_log(metadata: serde_json::Value, start: Option<&str>, end: Option<&str>) -> TaskLog {
+        TaskLog {
+            logs: Vec::new(),
+            metadata: Some(metadata),
+            start_time: start.map(|s| s.parse().expect("valid timestamp")),
+            end_time: end.map(|s| s.parse().expect("valid timestamp")),
+            outputs: Vec::new(),
+            system_logs: None,
+        }
+    }
+
+    #[test]
+    fn usage_folds_across_task_logs() {
+        // Two attempts: the second (a server-side retry) reports lower
+        // values, which must not regress the cumulative snapshot
+        let logs = [
+            task_log(
+                serde_json::json!({
+                    "peak_memory_bytes": "1000",
+                    "avg_memory_bytes": "800",
+                    "cpu_time_ms": "5000",
+                    "disk_used_bytes": "300",
+                }),
+                // 30 second attempt
+                Some("2026-08-26T00:00:00Z"),
+                Some("2026-08-26T00:00:30Z"),
+            ),
+            task_log(
+                serde_json::json!({
+                    "peak_memory_bytes": "400",
+                    "avg_memory_bytes": "200",
+                    "cpu_time_ms": "1000",
+                    "disk_used_bytes": "100",
+                }),
+                // 10 second attempt
+                Some("2026-08-26T00:01:00Z"),
+                Some("2026-08-26T00:01:10Z"),
+            ),
+        ];
+
+        let usage = fold_task_log_usage(&logs).expect("should have usage");
+        // Peaks take the maximum
+        assert_eq!(usage.max_memory, Some(1000));
+        assert_eq!(usage.disk_used, Some(300));
+        // CPU sums across attempts
+        assert_eq!(usage.cpu_time_ms, Some(6000));
+        // Average memory is duration-weighted: (800*30 + 200*10) / 40 = 650
+        assert_eq!(usage.avg_memory, Some(650));
+    }
+
+    #[test]
+    fn averages_fall_back_to_unweighted_without_timestamps() {
+        let logs = [
+            task_log(
+                serde_json::json!({ "avg_memory_bytes": "800" }),
+                Some("2026-08-26T00:00:00Z"),
+                Some("2026-08-26T00:00:30Z"),
+            ),
+            // No timestamps: the fold must not weight by duration
+            task_log(serde_json::json!({ "avg_memory_bytes": "200" }), None, None),
+        ];
+
+        let usage = fold_task_log_usage(&logs).expect("should have usage");
+        assert_eq!(usage.avg_memory, Some(500));
+    }
+
+    #[test]
+    fn logs_without_usage_fold_to_none() {
+        let logs = [task_log(serde_json::json!({}), None, None)];
+        assert!(fold_task_log_usage(&logs).is_none());
+
+        assert!(fold_task_log_usage(&[]).is_none());
+    }
 
     #[test]
     fn metadata_parses_numbers_and_numeric_strings() {

--- a/crankshaft-events/CHANGELOG.md
+++ b/crankshaft-events/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Added
 
+* Added the `TaskResourceUsage` event, carrying a cumulative
+  `TaskResourceUsage` snapshot of a task's observed resource utilization
+  (maximum/average resident memory, total/user/system CPU time, and disk
+  used); backends that can observe utilization emit it zero or more times
+  over a task's lifetime, and the last snapshot received is authoritative.
+* Added an optional `serde` feature that derives `Serialize`/`Deserialize`
+  for `TaskResourceUsage`.
 * Added `ImagePullStarted`, `ImagePullFinished`, and `ImagePullFailed` events ([#82](https://github.com/stjude-rust-labs/crankshaft/pull/82)).
 
 ## 0.1.0 - 09-03-2025

--- a/crankshaft-events/CHANGELOG.md
+++ b/crankshaft-events/CHANGELOG.md
@@ -13,9 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `TaskResourceUsage` snapshot of a task's observed resource utilization
   (maximum/average resident memory, total/user/system CPU time, and disk
   used); backends that can observe utilization emit it zero or more times
-  over a task's lifetime, and the last snapshot received is authoritative.
+  over a task's lifetime, and the last snapshot received is authoritative
+  ([#86](https://github.com/stjude-rust-labs/crankshaft/pull/86)).
 * Added an optional `serde` feature that derives `Serialize`/`Deserialize`
-  for `TaskResourceUsage`.
+  for `TaskResourceUsage`
+  ([#86](https://github.com/stjude-rust-labs/crankshaft/pull/86)).
 * Added `ImagePullStarted`, `ImagePullFinished`, and `ImagePullFailed` events ([#82](https://github.com/stjude-rust-labs/crankshaft/pull/82)).
 
 ## 0.1.0 - 09-03-2025

--- a/crankshaft-events/Cargo.toml
+++ b/crankshaft-events/Cargo.toml
@@ -12,7 +12,14 @@ rust-version.workspace = true
 [dependencies]
 bytes.workspace = true
 nonempty.workspace = true
+serde = { workspace = true, optional = true }
 tokio-util.workspace = true
+
+[dev-dependencies]
+serde_json = "1"
+
+[features]
+serde = ["dep:serde"]
 
 [lints]
 workspace = true

--- a/crankshaft-events/Cargo.toml
+++ b/crankshaft-events/Cargo.toml
@@ -16,7 +16,7 @@ serde = { workspace = true, optional = true }
 tokio-util.workspace = true
 
 [dev-dependencies]
-serde_json = "1"
+serde_json.workspace = true
 
 [features]
 serde = ["dep:serde"]

--- a/crankshaft-events/src/lib.rs
+++ b/crankshaft-events/src/lib.rs
@@ -35,6 +35,13 @@ pub struct TaskResourceUsage {
     /// The maximum resident memory observed, in bytes.
     pub max_memory: Option<u64>,
     /// The average resident memory observed, in bytes.
+    ///
+    /// The averaging method is producer-defined and averages are therefore
+    /// not comparable across backends: sampling backends typically report an
+    /// arithmetic mean over polling samples (which is not time-weighted and
+    /// may be skewed by missed or delayed ticks), while backends that forward
+    /// externally reported values (e.g. a TES server's task log metadata)
+    /// inherit that source's weighting.
     pub avg_memory: Option<u64>,
     /// The total CPU time consumed, in milliseconds.
     pub cpu_time_ms: Option<i64>,

--- a/crankshaft-events/src/lib.rs
+++ b/crankshaft-events/src/lib.rs
@@ -44,11 +44,11 @@ pub struct TaskResourceUsage {
     /// inherit that source's weighting.
     pub avg_memory: Option<u64>,
     /// The total CPU time consumed, in milliseconds.
-    pub cpu_time_ms: Option<i64>,
+    pub cpu_time_ms: Option<u64>,
     /// The user-mode CPU time consumed, in milliseconds.
-    pub user_cpu_time_ms: Option<i64>,
+    pub user_cpu_time_ms: Option<u64>,
     /// The system-mode CPU time consumed, in milliseconds.
-    pub system_cpu_time_ms: Option<i64>,
+    pub system_cpu_time_ms: Option<u64>,
     /// The disk space used, in bytes.
     pub disk_used: Option<u64>,
 }

--- a/crankshaft-events/src/lib.rs
+++ b/crankshaft-events/src/lib.rs
@@ -17,6 +17,42 @@ pub fn next_task_id() -> TaskId {
     NEXT_TASK_ID.fetch_add(1, Ordering::SeqCst)
 }
 
+/// The resource utilization observed for a task.
+///
+/// Every field is optional: backends report the subset of measurements their
+/// execution environment provides.
+///
+/// A backend reports utilization as a cumulative snapshot: each emission
+/// describes the task's utilization from its start up to the moment of
+/// observation, so the last snapshot received for a task is authoritative.
+/// Backends that can only observe utilization once (e.g. from a scheduler's
+/// accounting of a finished job) emit a single snapshot at the task's
+/// termination.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[non_exhaustive]
+pub struct TaskResourceUsage {
+    /// The maximum resident memory observed, in bytes.
+    pub max_memory: Option<u64>,
+    /// The average resident memory observed, in bytes.
+    pub avg_memory: Option<u64>,
+    /// The total CPU time consumed, in milliseconds.
+    pub cpu_time_ms: Option<i64>,
+    /// The user-mode CPU time consumed, in milliseconds.
+    pub user_cpu_time_ms: Option<i64>,
+    /// The system-mode CPU time consumed, in milliseconds.
+    pub system_cpu_time_ms: Option<i64>,
+    /// The disk space used, in bytes.
+    pub disk_used: Option<u64>,
+}
+
+impl TaskResourceUsage {
+    /// Returns whether the snapshot contains no measurements at all.
+    pub fn is_empty(&self) -> bool {
+        self == &Self::default()
+    }
+}
+
 /// An event sent by task execution backends.
 #[derive(Debug, Clone)]
 pub enum Event {
@@ -97,6 +133,20 @@ pub enum Event {
         /// The id of the task.
         id: TaskId,
     },
+    /// The resource utilization observed for a task.
+    ///
+    /// Backends that can observe resource utilization emit this event zero or
+    /// more times over the task's lifetime; each emission is a cumulative
+    /// snapshot and the last one received is authoritative (see
+    /// [`TaskResourceUsage`]). It may be emitted for any terminal outcome —
+    /// completed, failed, canceled, or preempted alike. Backends that cannot
+    /// observe utilization never emit this event.
+    TaskResourceUsage {
+        /// The id of the task.
+        id: TaskId,
+        /// The observed resource utilization.
+        usage: TaskResourceUsage,
+    },
     /// A task has logged stdout.
     ///
     /// Note: only locally executing tasks will send this event.
@@ -164,4 +214,36 @@ macro_rules! send_event {
             sender.send($event).ok();
         }
     };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_usage_snapshots_are_detected() {
+        assert!(TaskResourceUsage::default().is_empty());
+
+        let usage = TaskResourceUsage {
+            max_memory: Some(1024),
+            ..Default::default()
+        };
+        assert!(!usage.is_empty());
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn usage_snapshots_round_trip_through_serde() {
+        let usage = TaskResourceUsage {
+            max_memory: Some(241_172_480),
+            avg_memory: Some(100_000_000),
+            cpu_time_ms: Some(324_000),
+            ..Default::default()
+        };
+
+        let json = serde_json::to_string(&usage).expect("usage should serialize");
+        let parsed: TaskResourceUsage =
+            serde_json::from_str(&json).expect("usage should deserialize");
+        assert_eq!(parsed, usage);
+    }
 }

--- a/crankshaft-monitor/CHANGELOG.md
+++ b/crankshaft-monitor/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Added the `TaskResourceUsageEvent` protobuf message and forwarding of the
-  `TaskResourceUsage` event ([#XX](https://github.com/stjude-rust-labs/crankshaft/pull/XX)).
+  `TaskResourceUsage` event ([#86](https://github.com/stjude-rust-labs/crankshaft/pull/86)).
 * Added support for the `ImagePull{Started,Failed,Finished}` events ([#82](https://github.com/stjude-rust-labs/crankshaft/pull/82)).
 
 ## 0.2.0 - 02-11-2026

--- a/crankshaft-monitor/CHANGELOG.md
+++ b/crankshaft-monitor/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added the `TaskResourceUsageEvent` protobuf message and forwarding of the
+  `TaskResourceUsage` event ([#XX](https://github.com/stjude-rust-labs/crankshaft/pull/XX)).
 * Added support for the `ImagePull{Started,Failed,Finished}` events ([#82](https://github.com/stjude-rust-labs/crankshaft/pull/82)).
 
 ## 0.2.0 - 02-11-2026

--- a/crankshaft-monitor/src/proto/crankshaft.monitor.rs
+++ b/crankshaft-monitor/src/proto/crankshaft.monitor.rs
@@ -41,7 +41,7 @@ pub struct Event {
     pub timestamp: ::core::option::Option<::prost_types::Timestamp>,
     #[prost(
         oneof = "event::EventKind",
-        tags = "2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14"
+        tags = "2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15"
     )]
     pub event_kind: ::core::option::Option<event::EventKind>,
 }
@@ -89,6 +89,9 @@ pub mod event {
         /// The image pull finished event.
         #[prost(message, tag = "14")]
         ImagePullFinished(super::ImagePullFinishedEvent),
+        /// The task resource usage event.
+        #[prost(message, tag = "15")]
+        ResourceUsage(super::TaskResourceUsageEvent),
     }
 }
 /// Represents an exit status.
@@ -271,6 +274,36 @@ pub struct ImagePullFinishedEvent {
     /// The name of the image that was pulled.
     #[prost(string, tag = "2")]
     pub name: ::prost::alloc::string::String,
+}
+/// Represents a task resource usage event.
+///
+/// Each emission is a cumulative snapshot of the task's resource utilization;
+/// the last snapshot received for a task is authoritative. Fields that were
+/// not observed by the backend are unset.
+#[allow(clippy::all, missing_docs, clippy::missing_docs_in_private_items)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct TaskResourceUsageEvent {
+    /// The id of the task.
+    #[prost(uint64, tag = "1")]
+    pub id: u64,
+    /// The maximum resident memory observed, in bytes.
+    #[prost(uint64, optional, tag = "2")]
+    pub max_memory: ::core::option::Option<u64>,
+    /// The average resident memory observed, in bytes.
+    #[prost(uint64, optional, tag = "3")]
+    pub avg_memory: ::core::option::Option<u64>,
+    /// The total CPU time consumed, in milliseconds.
+    #[prost(int64, optional, tag = "4")]
+    pub cpu_time_ms: ::core::option::Option<i64>,
+    /// The user-mode CPU time consumed, in milliseconds.
+    #[prost(int64, optional, tag = "5")]
+    pub user_cpu_time_ms: ::core::option::Option<i64>,
+    /// The system-mode CPU time consumed, in milliseconds.
+    #[prost(int64, optional, tag = "6")]
+    pub system_cpu_time_ms: ::core::option::Option<i64>,
+    /// The disk space used, in bytes.
+    #[prost(uint64, optional, tag = "7")]
+    pub disk_used: ::core::option::Option<u64>,
 }
 /// Generated client implementations.
 #[allow(clippy::all, missing_docs, clippy::missing_docs_in_private_items)]

--- a/crankshaft-monitor/src/proto/crankshaft.monitor.rs
+++ b/crankshaft-monitor/src/proto/crankshaft.monitor.rs
@@ -293,14 +293,14 @@ pub struct TaskResourceUsageEvent {
     #[prost(uint64, optional, tag = "3")]
     pub avg_memory: ::core::option::Option<u64>,
     /// The total CPU time consumed, in milliseconds.
-    #[prost(int64, optional, tag = "4")]
-    pub cpu_time_ms: ::core::option::Option<i64>,
+    #[prost(uint64, optional, tag = "4")]
+    pub cpu_time_ms: ::core::option::Option<u64>,
     /// The user-mode CPU time consumed, in milliseconds.
-    #[prost(int64, optional, tag = "5")]
-    pub user_cpu_time_ms: ::core::option::Option<i64>,
+    #[prost(uint64, optional, tag = "5")]
+    pub user_cpu_time_ms: ::core::option::Option<u64>,
     /// The system-mode CPU time consumed, in milliseconds.
-    #[prost(int64, optional, tag = "6")]
-    pub system_cpu_time_ms: ::core::option::Option<i64>,
+    #[prost(uint64, optional, tag = "6")]
+    pub system_cpu_time_ms: ::core::option::Option<u64>,
     /// The disk space used, in bytes.
     #[prost(uint64, optional, tag = "7")]
     pub disk_used: ::core::option::Option<u64>,

--- a/crankshaft-monitor/src/proto/monitor.proto
+++ b/crankshaft-monitor/src/proto/monitor.proto
@@ -69,6 +69,8 @@ message Event {
     ImagePullFailedEvent image_pull_failed = 13;
     // The image pull finished event.
     ImagePullFinishedEvent image_pull_finished = 14;
+    // The task resource usage event.
+    TaskResourceUsageEvent resource_usage = 15;
   }
 }
 
@@ -202,4 +204,26 @@ message ImagePullFinishedEvent {
   uint64 id = 1;
   // The name of the image that was pulled.
   string name = 2;
+}
+
+// Represents a task resource usage event.
+//
+// Each emission is a cumulative snapshot of the task's resource utilization;
+// the last snapshot received for a task is authoritative. Fields that were
+// not observed by the backend are unset.
+message TaskResourceUsageEvent {
+  // The id of the task.
+  uint64 id = 1;
+  // The maximum resident memory observed, in bytes.
+  optional uint64 max_memory = 2;
+  // The average resident memory observed, in bytes.
+  optional uint64 avg_memory = 3;
+  // The total CPU time consumed, in milliseconds.
+  optional int64 cpu_time_ms = 4;
+  // The user-mode CPU time consumed, in milliseconds.
+  optional int64 user_cpu_time_ms = 5;
+  // The system-mode CPU time consumed, in milliseconds.
+  optional int64 system_cpu_time_ms = 6;
+  // The disk space used, in bytes.
+  optional uint64 disk_used = 7;
 }

--- a/crankshaft-monitor/src/proto/monitor.proto
+++ b/crankshaft-monitor/src/proto/monitor.proto
@@ -219,11 +219,11 @@ message TaskResourceUsageEvent {
   // The average resident memory observed, in bytes.
   optional uint64 avg_memory = 3;
   // The total CPU time consumed, in milliseconds.
-  optional int64 cpu_time_ms = 4;
+  optional uint64 cpu_time_ms = 4;
   // The user-mode CPU time consumed, in milliseconds.
-  optional int64 user_cpu_time_ms = 5;
+  optional uint64 user_cpu_time_ms = 5;
   // The system-mode CPU time consumed, in milliseconds.
-  optional int64 system_cpu_time_ms = 6;
+  optional uint64 system_cpu_time_ms = 6;
   // The disk space used, in bytes.
   optional uint64 disk_used = 7;
 }

--- a/crankshaft-monitor/src/service.rs
+++ b/crankshaft-monitor/src/service.rs
@@ -227,6 +227,23 @@ impl MonitorService {
                             let event: Event = event.into_protobuf();
                             let mut state = state.write().await;
                             if let Some(task) = state.tasks.get_mut(&id) {
+                                // Resource usage events are cumulative
+                                // snapshots where only the latest is
+                                // authoritative; replace the previously
+                                // retained snapshot instead of growing the
+                                // task's history once per sampling interval
+                                if matches!(
+                                    event.event_kind,
+                                    Some(EventKind::ResourceUsage(_))
+                                ) {
+                                    task.events.retain(|e| {
+                                        !matches!(
+                                            e.event_kind,
+                                            Some(EventKind::ResourceUsage(_))
+                                        )
+                                    });
+                                }
+
                                 task.events.push(event);
                             }
                         }

--- a/crankshaft-monitor/src/service.rs
+++ b/crankshaft-monitor/src/service.rs
@@ -37,6 +37,7 @@ use crate::proto::TaskCreatedEvent;
 use crate::proto::TaskEvents;
 use crate::proto::TaskFailedEvent;
 use crate::proto::TaskPreemptedEvent;
+use crate::proto::TaskResourceUsageEvent;
 use crate::proto::TaskStartedEvent;
 use crate::proto::TaskStderrEvent;
 use crate::proto::TaskStdoutEvent;
@@ -128,6 +129,17 @@ impl IntoProtobuf<EventKind> for CrankshaftEvent {
             CrankshaftEvent::ImagePullFinished { id, name } => {
                 EventKind::ImagePullFinished(ImagePullFinishedEvent { id, name })
             }
+            CrankshaftEvent::TaskResourceUsage { id, usage } => {
+                EventKind::ResourceUsage(TaskResourceUsageEvent {
+                    id,
+                    max_memory: usage.max_memory,
+                    avg_memory: usage.avg_memory,
+                    cpu_time_ms: usage.cpu_time_ms,
+                    user_cpu_time_ms: usage.user_cpu_time_ms,
+                    system_cpu_time_ms: usage.system_cpu_time_ms,
+                    disk_used: usage.disk_used,
+                })
+            }
         }
     }
 }
@@ -193,7 +205,8 @@ impl MonitorService {
                             | CrankshaftEvent::TaskContainerCreated { id, .. }
                             | CrankshaftEvent::TaskContainerExited { id, .. }
                             | CrankshaftEvent::TaskStdout { id, .. }
-                            | CrankshaftEvent::TaskStderr { id, .. } => (id, false),
+                            | CrankshaftEvent::TaskStderr { id, .. }
+                            | CrankshaftEvent::TaskResourceUsage { id, .. } => (id, false),
                             CrankshaftEvent::TaskCompleted { id, .. }
                             | CrankshaftEvent::TaskFailed { id, .. }
                             | CrankshaftEvent::TaskCanceled { id }


### PR DESCRIPTION
This PR introduces a vocabulary for reporting task resource usage through Crankshaft's event system, plus two producers: a sampling-based one for the Docker backend and a metadata-based one for the TES backend.

The motivation is enabling engines built on Crankshaft (e.g. sprocket) to report per-task peak/average memory, CPU time, and disk usage in their execution metrics.

TES changes to Planetary are here: https://github.com/stjude-rust-labs/planetary/pull/48

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [ ] You have updated the README or other documentation to account for these changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
