### PR TITLE
feat: add Docker `run_without_events`

### DIFF
--- a/crankshaft-engine/CHANGELOG.md
+++ b/crankshaft-engine/CHANGELOG.md
@@ -8,6 +8,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Added
+
+* Added `docker::Backend::run_without_events()` for internal tasks that must not
+  expose externally cancelable task tokens
+  ([#88](https://github.com/stjude-rust-labs/crankshaft/pull/88)).
+
 ### Changed
 
 * Event channels are now passed to `run` instead of at the time of backend

--- a/crankshaft-engine/src/service/runner/backend/docker.rs
+++ b/crankshaft-engine/src/service/runner/backend/docker.rs
@@ -328,6 +328,20 @@ impl Backend {
         Self::initialize_default_with(Config::default(), names).await
     }
 
+    /// Runs an internal task without broadcasting events.
+    ///
+    /// Use this for backend housekeeping that was not requested by the user and
+    /// must not expose a per-task cancellation token through
+    /// [`Event::TaskCreated`]. The task can only be canceled through the
+    /// `token` supplied by the caller.
+    pub fn run_without_events(
+        &self,
+        task: Task,
+        token: CancellationToken,
+    ) -> Result<BoxFuture<'static, Result<NonEmpty<ExecutionResult>, TaskRunError>>> {
+        <Self as crate::Backend>::run(self, task, None, token)
+    }
+
     /// Gets a reference to the inner Docker client.
     pub fn client(&self) -> &Docker {
         &self.client
@@ -989,6 +1003,51 @@ mod test {
         let task_id1 = assert_events(&events1, b"task1\n");
         let task_id2 = assert_events(&events2, b"task2\n");
         assert!(task_id1 != task_id2, "expected different task identifiers");
+
+        Ok(())
+    }
+
+    fn internal_task() -> Result<Task> {
+        Ok(Task::builder()
+            .executions(NonEmpty::new(
+                Execution::builder()
+                    .images(["ubuntu:latest"])?
+                    .program("/bin/true")
+                    .build(),
+            ))
+            .build())
+    }
+
+    #[tokio::test]
+    async fn backend_run_without_events_completes() -> anyhow::Result<()> {
+        let backend = create_backend(Config::default()).await?;
+
+        let results = backend
+            .run_without_events(internal_task()?, CancellationToken::new())
+            .context("failed to run internal task")?
+            .await
+            .context("internal task execution failed")?;
+
+        assert!(
+            results.first().status.success(),
+            "internal container failed"
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn backend_run_without_events_honors_caller_token() -> anyhow::Result<()> {
+        let backend = create_backend(Config::default()).await?;
+        let token = CancellationToken::new();
+        token.cancel();
+
+        let result = backend
+            .run_without_events(internal_task()?, token)
+            .context("failed to run internal task")?
+            .await;
+
+        assert_matches!(result, Err(TaskRunError::Canceled));
 
         Ok(())
     }


### PR DESCRIPTION
Crankshaft lacked an explicit Docker API for internal housekeeping tasks that must stay off the event stream. Event consumers can cancel ordinary tasks through the token carried by `Event::TaskCreated`, which can incorrectly cancel cleanup started after a user interruption.

I added `docker::Backend::run_without_events`, which delegates to the existing Docker runner with no event sender. It preserves the normal container and service behavior while making the caller-provided token the only cancellation path exposed through Crankshaft. Sprocket will use this API to remove its second-backend workaround for the cleanup tracked by stjude-rust-labs/sprocket#1020.

I left TES and generic backends unchanged because this housekeeping use case is Docker-specific. Backend-agnostic callers can already pass `None` to the shared `Backend::run` API if they need the same event behavior.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
